### PR TITLE
Control timespan

### DIFF
--- a/analyze
+++ b/analyze
@@ -1,0 +1,294 @@
+#!/bin/bash
+
+#compute time-bound stats from a autodevstats datadir
+#input env vars:
+#EARLIEST_PR a "Z" terminated iso-8601 date string indicating
+#   earliest date to consider in analysis
+#DATADIR the location of autodevstats data fetched and prepped
+#stats will be written to stdout
+
+#allow passing some environment vairables to override some automated steps
+
+#enter safe-mode (no more undefined variables!)
+set -eu -o pipefail
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+echo "performing timespan analysis since $EARLIEST_PR" > /dev/stderr
+
+#set up state from datadir
+
+if [ -z "${DATADIR}" ] || [ ! -e "${DATADIR}" ] || [ ! -d "${DATADIR}" ]; then
+    echo "DATDIR, \"${DATADIR}\", must exist and be a directory to perform autodevstats analysis" > /dev/stderr
+    exit 1
+fi
+
+ANALYSISDIR=${DATADIR}/analysis
+
+rm -rf ${ANALYSISDIR}
+mkdir ${ANALYSISDIR}
+
+#set up some necessary analysis data
+echo "preparing analysis data..." > /dev/stderr
+
+#gather PR status
+echo "prepping pr statuses..." > /dev/stderr
+pv ${DATADIR}/pulls.gz | zcat |\
+    jq -r '.[] | [.number, if .merged_at != null then "merged" else .state end, .created_at, .closed_at, .merge_commit_sha] | @tsv' |\
+    gawk -F\\t '$3 >= "'${EARLIEST_PR}'"' |\
+    LC_ALL=C sort \
+    > ${ANALYSISDIR}/pr_status
+
+echo "preparing a sample of reviewed and unreviewed commits..." > /dev/stderr
+
+> ${ANALYSISDIR}/reviewed_commits.tmp
+
+#commits with known GH templates
+cat ${DATADIR}/commit_messages |\
+    ag -A1 '^__commit__ [0-9a-f]{40}$' |\
+    gawk 'BEGIN {OFS="\t"} /^__commit__ [a-f0-9]{40}$/ {commit=$2} !/^__commit__ [a-f0-9]{40}$/ {print commit, $0}' |\
+    gawk -F\\t 'BEGIN {OFS="\t"} {if(match($2, /(Merge pull request #([0-9]+))|(\(#([0-9]+)\)$)/, m) > 0) { if(m[2] == "") { print m[4], $1} else { print m[2], $1}}}' |\
+    LC_ALL=C sort | LC_ALL=C join -t$'\t' - ${ANALYSISDIR}/pr_status |\
+    gawk -F\\t 'BEGIN {OFS="\t"} {print $2, $1}' | LC_ALL=C sort -u\
+    >> ${ANALYSISDIR}/reviewed_commits.tmp
+
+#commits from external merge tools
+cat ${DATADIR}/commit_autolinks |\
+    (ag 'closes' || true) |\
+    gawk -F\\t 'BEGIN {OFS="\t"} {print $2,$1}' |\
+    LC_ALL=C sort | LC_ALL=C join -t$'\t' - ${ANALYSISDIR}/pr_status |\
+    gawk -F\\t 'BEGIN {OFS="\t"} {print $2,$1}' | LC_ALL=C sort -u\
+    >> ${ANALYSISDIR}/reviewed_commits.tmp
+
+#commits listed in merge_commit_sha for merged PRs
+cat ${ANALYSISDIR}/pr_status |\
+    (ag 'merged' || true) |\
+    gawk -F\\t 'BEGIN {OFS="\t"} {print $5,$1}' |\
+    LC_ALL=C sort | LC_ALL=C join -t$'\t' - ${DATADIR}/commitdates |\
+    cut -f 1,2\
+    >> ${ANALYSISDIR}/reviewed_commits.tmp
+
+cat ${ANALYSISDIR}/reviewed_commits.tmp | LC_ALL=C sort -u\
+    > ${ANALYSISDIR}/reviewed_commits
+rm ${ANALYSISDIR}/reviewed_commits.tmp
+
+#the complement, but during the right period
+cat ${DATADIR}/commitdates |\
+    gawk -F\\t '$2 >='$(date -d ${EARLIEST_PR} +%s) | cut -f1 |
+    LC_ALL=C join -v1 - ${ANALYSISDIR}/reviewed_commits \
+    > ${ANALYSISDIR}/unreviewed_commits
+
+AVG_COMMENT_TIME=$(\
+    cat ${DATADIR}/pr_comments_data |\
+    gawk -F\\t '$6 >= "'${EARLIEST_PR}'"' |\
+    gawk -F\\t -i ${DIR}/date.awk -i ${DIR}/reduce.awk -f ${DIR}/extractplies.awk |\
+    gawk -F\\t -i ${DIR}/reduce.awk 'BEGIN {OFS="\t";setkey("1\t2\t3");} function startrun(key) {state=$6;startts=$4;comments=0;sumtime=0;lastts=$4} function reduce(key) {if(comments>0) {print $4-lastts;} comments+=1; lastts=$4} function endrun(key) { }' |\
+    gawk '{s+=$1;n+=1} END {if(n>0) { print s/n } else { print 0} }')
+
+#start computing stats
+echo "doing analysis..." > /dev/stderr
+
+echo "code birthdate summary (during analysis period)" > /dev/stderr
+pv ${DATADIR}/metadata.gz | zcat |\
+    gawk -F\\t '$7 >='$(date -d ${EARLIEST_PR} +%s) |\
+    cut -f 4,7 |\
+    gawk -M -f ${DIR}/groupstats.awk |\
+    jq -c --slurp --raw-input --arg stat_name during_pr_code_birthdate_summary -f ${DIR}/gs2json.jq
+
+echo "code lifetime summary (during analysis period)" > /dev/stderr
+pv ${DATADIR}/metadata.gz | zcat |\
+    gawk -F\\t '$7 >='$(date -d ${EARLIEST_PR} +%s) |\
+    cut -f4,5 |\
+    gawk -M -f ${DIR}/groupstats.awk |\
+    jq -c --slurp --raw-input --arg stat_name during_pr_code_lifetime_summary -f ${DIR}/gs2json.jq
+
+echo "dead code lifetime distribution (during analysis period)" > /dev/stderr
+pv ${DATADIR}/metadata.gz | zcat |\
+    gawk -F\\t '$7 >='$(date -d ${EARLIEST_PR} +%s) |\
+    ag 'died' | cut -f 5 | sort -n |\
+    gawk -f ${DIR}/cdf.awk <(echo -n "86400_604800_1209600_2592000_5184000_7776000_15552000_31104000" | tr '_' '\n') - |\
+    jq -c --slurp --raw-input --arg stat_name during_pr_code_lifetime_died_cdf -f ${DIR}/cdf2json.jq
+
+echo "live code lifetime distribution (during analysis period)" > /dev/stderr
+pv ${DATADIR}/metadata.gz | zcat |\
+    gawk -F\\t '$7 >='$(date -d ${EARLIEST_PR} +%s) |\
+    ag 'live' | cut -f 5 | sort -n |\
+    gawk -f ${DIR}/cdf.awk <(echo -n "86400_604800_1209600_2592000_5184000_7776000_15552000_31104000" | tr '_' '\n') - |\
+    jq -c --slurp --raw-input --arg stat_name during_pr_code_lifetime_live_cdf -f ${DIR}/cdf2json.jq
+
+echo "comments per dev-PR" > /dev/stderr
+cat ${DATADIR}/pr_comments_data | cut -f 1,2,4 |\
+    gawk 'BEGIN {OFS="\t"} { print $1,$2,$3; print $1,$2,"any"}' |\
+    cut -f 1,3 | LC_ALL=C sort | uniq -c |\
+    gawk 'BEGIN {OFS="\t"} {print $2,$3,$1}' |\
+    LC_ALL=C join -t$'\t' - ${ANALYSISDIR}/pr_status | gawk -F\\t '{printf("%s-%s\t%d\n", $4,$2,$3)}' |\
+    gawk -M -f ${DIR}/groupstats.awk |\
+    jq -c --slurp --raw-input --arg stat_name comment_per_dev_pr -f ${DIR}/gs2json.jq
+
+echo "comments per dev" > /dev/stderr
+cat ${DATADIR}/pr_comments_data | cut -f 1,2,4 |\
+    gawk -F\\t 'BEGIN {OFS="\t"} { print $1,$2,$3; print $1,$2,"any"}' |\
+    LC_ALL=C join -t$'\t' - ${ANALYSISDIR}/pr_status |\
+    gawk -F\\t '$2!="" {printf("%s\t%s-%s\n", $2,$4,$3)}' | sort | uniq -c | gawk '{print $3,$1}' |\
+    gawk -M -f ${DIR}/groupstats.awk |\
+    jq -c --slurp --raw-input --arg stat_name comment_per_dev -f ${DIR}/gs2json.jq
+
+echo "overlap in files for reviewed vs unreviewed commits" > /dev/stderr
+cat\
+    <(cat ${ANALYSISDIR}/unreviewed_commits | gawk -v commits=$(cat ${ANALYSISDIR}/unreviewed_commits | wc -l) '{printf("%s\t%s\t%f\n", $1, "unreviewed", 1.0/commits)}')\
+    <(cat ${ANALYSISDIR}/reviewed_commits | gawk -v commits=$(cat ${ANALYSISDIR}/reviewed_commits | wc -l) '{printf("%s\t%s\t%f\n", $1, "reviewed", 1.0/commits)}') |\
+    LC_ALL=C sort | LC_ALL=C join -t$'\t' -\
+        <(cat ${DATADIR}/filestatus | cut -f 1,4 | LC_ALL=C sort) |\
+    gawk 'BEGIN {OFS="\t"} {print $4,$2,$3}' |\
+    LC_ALL=C sort |\
+    gawk -F\\t -i ${DIR}/reduce.awk -f ${DIR}/jaccard.awk |\
+    jq -c --slurp --raw-input --arg stat_name commit_review_file_overlap -f ${DIR}/gs2json.jq
+
+echo "lines of code for reviewed vs unreviewed commits by outcome" > /dev/stderr
+cat\
+    <(cat ${ANALYSISDIR}/reviewed_commits | cut -f1 | gawk '{printf("%s\treviewed\n", $1)}')\
+    <(cat ${ANALYSISDIR}/unreviewed_commits | cut -f1 | gawk '{printf("%s\tunreviewed\n", $1)}') |\
+    LC_ALL=C sort |\
+    LC_ALL=C join <(zcat ${DATADIR}/metadata.gz | cut -f 2,4 | LC_ALL=C sort) - |\
+    LC_ALL=C sort | uniq -c |\
+    gawk '{printf("%s-%s\t%d\n",$4,$3,$1)}' |\
+    gawk -M -f ${DIR}/groupstats.awk |\
+    jq -c --slurp --raw-input --arg stat_name commit_review_size_by_outcome -f ${DIR}/gs2json.jq
+
+echo "dates for reviewed vs unreviewed commits" > /dev/stderr
+cat\
+    <(cat ${ANALYSISDIR}/reviewed_commits | cut -f 1 |\
+        LC_ALL=C join -t$'\t' - ${DATADIR}/commitdates |\
+        gawk -F\\t '{printf("reviewed\t%f\n", $2)}')\
+    <(cat ${ANALYSISDIR}/unreviewed_commits |\
+        LC_ALL=C join -t$'\t' - ${DATADIR}/commitdates |\
+        gawk -F\\t '{printf("unreviewed\t%f\n", $2)}') |\
+    gawk -M -f ${DIR}/groupstats.awk |\
+    jq -c --slurp --raw-input --arg stat_name commit_review_vs_date -f ${DIR}/gs2json.jq
+
+echo "lifetime for code from reviewed vs unreviewed commits" > /dev/stderr
+cat\
+    <(cat ${ANALYSISDIR}/reviewed_commits | cut -f 1 |\
+        gawk -F\\t '{printf("%s\treviewed\n", $1)}')\
+    <(cat ${ANALYSISDIR}/unreviewed_commits |\
+        gawk -F\\t '{printf("%s\tunreviewed\n", $1)}') |\
+    LC_ALL=C sort |\
+    LC_ALL=C join -t$'\t' - <(zcat ${DATADIR}/metadata.gz | cut -f 2,5 | LC_ALL=C sort) | cut -f 2,3 |\
+    gawk -M -f ${DIR}/groupstats.awk |\
+    jq -c --slurp --raw-input --arg stat_name commit_review_vs_lifetime -f ${DIR}/gs2json.jq
+
+cat\
+    <(cat ${ANALYSISDIR}/reviewed_commits | cut -f 1 |\
+        gawk -F\\t '{printf("%s\treviewed\n", $1)}')\
+    <(cat ${ANALYSISDIR}/unreviewed_commits |\
+        gawk -F\\t '{printf("%s\tunreviewed\n", $1)}') |\
+    LC_ALL=C sort |\
+    LC_ALL=C join -t$'\t' - <(zcat ${DATADIR}/metadata.gz | ag 'died' | cut -f 2,5 | LC_ALL=C sort) | cut -f 2,3 |\
+    gawk -M -f ${DIR}/groupstats.awk |\
+    jq -c --slurp --raw-input --arg stat_name commit_review_vs_lifetime_died -f ${DIR}/gs2json.jq
+
+cat\
+    <(cat ${ANALYSISDIR}/reviewed_commits | cut -f 1 |\
+        gawk -F\\t '{printf("%s\treviewed\n", $1)}')\
+    <(cat ${ANALYSISDIR}/unreviewed_commits |\
+        gawk -F\\t '{printf("%s\tunreviewed\n", $1)}') |\
+    LC_ALL=C sort |\
+    LC_ALL=C join -t$'\t' - <(zcat ${DATADIR}/metadata.gz | ag 'live' | cut -f 2,5 | LC_ALL=C sort) | cut -f 2,3 |\
+    gawk -M -f ${DIR}/groupstats.awk |\
+    jq -c --slurp --raw-input --arg stat_name commit_review_vs_lifetime_live -f ${DIR}/gs2json.jq
+
+echo "devs per PR" > /dev/stderr
+cat ${DATADIR}/pr_comments_data | cut -f 1,2,4 | sort -u |\
+    gawk -F\\t 'BEGIN {OFS="\t"} { print $0; print $1,$2,"any"}' |\
+    cut -f 1,3 | LC_ALL=C sort | uniq -c |\
+    gawk 'BEGIN {OFS="\t"} {print $2,$3,$1}' |\
+    LC_ALL=C join -t$'\t' - ${ANALYSISDIR}/pr_status | gawk -F\\t '{printf("%s-%s\t%d\n", $4,$2,$3)}' |\
+    gawk -M -f ${DIR}/groupstats.awk |\
+    jq -c --slurp --raw-input --arg stat_name dev_per_pr -f ${DIR}/gs2json.jq
+
+echo "commit distribution across authors (during analysis period)" > /dev/stderr
+cat ${DATADIR}/commits_with_author |\
+    LC_ALL=C join -t$'\t' - <(cat ${ANALYSISDIR}/reviewed_commits ${ANALYSISDIR}/unreviewed_commits | LC_ALL=C sort) |\
+    gawk -F\\t '{print $2}' | sort | uniq -c | sort -rn |\
+    gawk '{d[NR]=$1;s+=$1;} END {c=0; for (x in d) { c+=d[x]/s; print c}}' |\
+    gawk -f ${DIR}/cdf.awk <(echo "0.1_0.25_0.5_0.75_0.8_0.9_0.95_0.99_1" | tr '_' '\n') - |\
+    jq --slurp --raw-input --arg stat_name during_pr_commits_proportion_by_dev_cdf -f ${DIR}/cdf2json.jq
+
+echo "PR merge commits during analysis period" > /dev/stderr
+printf "%d\t%d\t%d\t%d\n"\
+    $(cat ${DATADIR}/commit_messages | ag '__commit__ [a-f0-9]{40}' | gawk '{print $2}' | LC_ALL=C sort | LC_ALL=C join - ${DATADIR}/commitdates | gawk '$2 >= '$(date -d ${EARLIEST_PR} +%s) | wc -l)\
+    $(cat ${DATADIR}/commit_messages | (grep -E -o 'Merge pull request #[0-9]+ from' || true) | grep -o '[0-9]*' | LC_ALL=C sort | LC_ALL=C join - ${ANALYSISDIR}/pr_status | wc -l)\
+    $(cat ${DATADIR}/commit_messages | (grep -E -A1 '^__commit__ [a-f0-9]{40}$' || true) | (grep -E -o ' \(#[0-9]+\)$' || true) | grep -o '[0-9]*' | LC_ALL=C sort | LC_ALL=C join - ${ANALYSISDIR}/pr_status | wc -l)\
+    $(cat ${DATADIR}/commit_autolinks | grep 'close' | cut -f 2 | LC_ALL=C sort | LC_ALL=C join - ${ANALYSISDIR}/pr_status | wc -l) |\
+    jq -c --slurp --raw-input 'split("\t") | {"stat":"gh_merges_during_prs", "data":{"commits":(.[0]|tonumber), "gh_merges":(.[1]|tonumber), "gh_likely_merge":(.[2]|tonumber), "likely_external_merge":(.[3]|tonumber)}}'
+
+echo "comparing GH commit pull association with commit message analysis" > /dev/stderr
+cat ${DATADIR}/commit_pulls |\
+    sed -E 's/^https:\/\/api.github.com\/repos\/[^\/]*\/[^\/]*\/commits\/([a-f0-9]{40})\/pulls/\1/' |\
+    LC_ALL=C sort | LC_ALL=C join -t$'\t' - <(cat ${ANALYSISDIR}/reviewed_commits ${ANALYSISDIR}/unreviewed_commits | LC_ALL=C sort) |\
+    jq -r -R 'split("\t") | [.[0], (.[1] | fromjson | length), .[2]] | @tsv' |\
+    gawk -F\\t '$3=="" {printf("unreviewed\t%d\n",$2>0)} $3!="" {printf("reviewed\t%d\n",$2>0)}' |\
+    gawk -M -f ${DIR}/groupstats.awk |\
+    jq -c --slurp --raw-input --arg stat_name gh_rev_vs_commit_rev -f ${DIR}/gs2json.jq
+
+cat ${DATADIR}/commit_pulls |\
+    sed -E 's/^https:\/\/api.github.com\/repos\/[^\/]*\/[^\/]*\/commits\/([a-f0-9]{40})\/pulls/\1/' |\
+    LC_ALL=C sort | LC_ALL=C join -t$'\t' - <(cat ${ANALYSISDIR}/reviewed_commits ${ANALYSISDIR}/unreviewed_commits | LC_ALL=C sort) |\
+    jq -r -R 'split("\t") | [.[0], (.[2] as $prnumber | .[1] | fromjson | map(.number) | select(($prnumber // "0" | tonumber))|length), .[2]] | @tsv' |\
+    gawk -F\\t '$3=="" {printf("unreviewed\t%d\n",$2>0)} $3!="" {printf("reviewed\t%d\n",$2>0)}' |\
+    gawk -M -f ${DIR}/groupstats.awk |\
+    jq -c --slurp --raw-input --arg stat_name gh_rev_vs_commit_rev_strict -f ${DIR}/gs2json.jq
+
+echo "PR comment count summary" > /dev/stderr
+cat ${DATADIR}/commentcounts | LC_ALL=C sort | join -t$'\t' ${ANALYSISDIR}/pr_status - | gawk -F\\t '{printf("%s-%s\t%d\n", $2, $6, $7)}' |\
+    gawk -F\\t -M -f ${DIR}/groupstats.awk |\
+    jq -c --slurp --raw-input --arg stat_name pr_comment_summary -f ${DIR}/gs2json.jq
+
+echo "PR lifetime summary" > /dev/stderr
+cat ${ANALYSISDIR}/pr_status | gawk -F\\t -i ${DIR}/date.awk 'BEGIN {OFS="\t"} $2=="open" {print $2, systime() - parsedate($3)} $2!="open" { print $2, parsedate($4) - parsedate($3)}' |\
+    gawk -M -f ${DIR}/groupstats.awk |\
+    jq -c --slurp --raw-input --arg stat_name pr_lifetime_summary -f ${DIR}/gs2json.jq
+echo "PR cycle count per PR by outcome" > /dev/stderr
+cat ${DATADIR}/pr_comments_data |\
+    gawk -F\\t '$6 >= "'${EARLIEST_PR}'"' |\
+    gawk -F\\t -i ${DIR}/date.awk -i ${DIR}/reduce.awk -f ${DIR}/extractplies.awk |\
+    cut -f 1,2,3,6 | uniq | cut -f1,4 | uniq -c | gawk '{print $3,$1}' |\
+    gawk -M -f ${DIR}/groupstats.awk |\
+    jq -c --slurp --raw-input --arg stat_name pr_plies_per_pr -f ${DIR}/gs2json.jq
+
+echo "PR active review time by outcome" > /dev/stderr
+cat ${DATADIR}/pr_comments_data |\
+    gawk -F\\t '$6 >= "'${EARLIEST_PR}'"' |\
+    gawk -F\\t -i ${DIR}/date.awk -i ${DIR}/reduce.awk -f ${DIR}/extractplies.awk |\
+    gawk -F\\t -i ${DIR}/reduce.awk -v avgctime=$AVG_COMMENT_TIME 'BEGIN {OFS="\t";setkey("1\t2\t3");} function startrun(key) {state=$6;startts=$4;comments=0;lastts=$4} function reduce(key) { comments+=1;lastts=$4} function endrun(key) { print key[1], key[2], key[3], comments, comments*avgctime, lastts-startts, state}' |\
+    gawk -F\\t -i ${DIR}/reduce.awk 'BEGIN {OFS="\t";setkey("1");} function startrun(key) {estimate=0;flr=0;state=$7} function reduce(key) {estimate+=$5;flr+=$6} function endrun(key) { printf("%s-estimate\t%f\n", state, estimate);printf("%s-floorwzero\t%f\n", state, flr);}' |\
+    gawk -M -f ${DIR}/groupstats.awk |\
+    jq -c --slurp --raw-input --arg stat_name pr_time_per_pr -f ${DIR}/gs2json.jq
+
+echo "PR active review time by outcome including zero engagement reviews" > /dev/stderr
+cat ${DATADIR}/pr_comments_data |\
+    gawk -F\\t '$6 >= "'${EARLIEST_PR}'"' |\
+    gawk -F\\t -i ${DIR}/date.awk -i ${DIR}/reduce.awk -f ${DIR}/extractplies.awk |\
+    gawk -F\\t -i ${DIR}/reduce.awk -v avgctime=$AVG_COMMENT_TIME 'BEGIN {OFS="\t";setkey("1\t2\t3");} function startrun(key) {state=$6;startts=$4;comments=0;lastts=$4} function reduce(key) { comments+=1;lastts=$4} function endrun(key) { print key[1], key[2], key[3], comments, comments*avgctime, lastts-startts, state}' |\
+    LC_ALL=C join -t$'\t' -o 0,2.2,2.3,2.4,2.5,2.6,1.2 -a1 ${ANALYSISDIR}/pr_status - |\
+    gawk -F\\t -i ${DIR}/reduce.awk 'BEGIN {OFS="\t";setkey("1");} function startrun(key) {estimate=0;flr=0;state=$7} function reduce(key) {estimate+=$5;flr+=$6} function endrun(key) { printf("%s-estimate\t%f\n", state, estimate);printf("%s-floorwzero\t%f\n", state, flr);}' |\
+    gawk -M -f ${DIR}/groupstats.awk |\
+    jq -c --slurp --raw-input --arg stat_name pr_time_per_pr_wzero -f ${DIR}/gs2json.jq
+
+echo "commit distribution across authors (reviewed)" > /dev/stderr
+cat ${DATADIR}/commits_with_author |\
+    LC_ALL=C join -t$'\t' - ${ANALYSISDIR}/reviewed_commits |\
+    gawk -F\\t '{print $2}' | sort | uniq -c | sort -rn |\
+    gawk '{d[NR]=$1;s+=$1;} END {c=0; for (x in d) { c+=d[x]/s; print c}}' |\
+    gawk -f ${DIR}/cdf.awk <(echo "0.1_0.25_0.5_0.75_0.8_0.9_0.95_0.99_1" | tr '_' '\n') - |\
+    jq --slurp --raw-input --arg stat_name rev_commits_proportion_by_dev_cdf -f ${DIR}/cdf2json.jq
+
+echo "commit distribution across authors (unreviewed)" > /dev/stderr
+cat ${DATADIR}/commits_with_author |\
+    LC_ALL=C join -t$'\t' - ${ANALYSISDIR}/unreviewed_commits |\
+    gawk -F\\t '{print $2}' | sort | uniq -c | sort -rn |\
+    gawk '{d[NR]=$1;s+=$1;} END {c=0; for (x in d) { c+=d[x]/s; print c}}' |\
+    gawk -f ${DIR}/cdf.awk <(echo "0.1_0.25_0.5_0.75_0.8_0.9_0.95_0.99_1" | tr '_' '\n') - |\
+    jq --slurp --raw-input --arg stat_name unrev_commits_proportion_by_dev_cdf -f ${DIR}/cdf2json.jq
+
+echo "done with analysis back to ${EARLIEST_PR}" > /dev/stderr

--- a/analyze
+++ b/analyze
@@ -26,6 +26,8 @@ fi
 
 ANALYSISDIR=${DATADIR}/analysis
 
+REPO=$(cat ${DATADIR}/repo | jq -r '.full_name')
+
 rm -rf ${ANALYSISDIR}
 mkdir ${ANALYSISDIR}
 
@@ -33,12 +35,23 @@ mkdir ${ANALYSISDIR}
 echo "preparing analysis data..." > /dev/stderr
 
 #gather PR status
+#limit by EARLIEST_PR (using closed date, or created date if we have to)
+#also drop pulls that are FROM the default branch on the main repo
+#   we'll assume prs from other branches are bound for mainline eventually
 echo "prepping pr statuses..." > /dev/stderr
 pv ${DATADIR}/pulls.gz | zcat |\
-    jq -r '.[] | [.number, if .merged_at != null then "merged" else .state end, .created_at, .closed_at, .merge_commit_sha] | @tsv' |\
-    gawk -F\\t '$3 >= "'${EARLIEST_PR}'"' |\
+    jq -r --arg default_branch $DEFAULT_BRANCH --arg full_name $REPO '.[] | select(.head.ref != $default_branch or .head.repo.full_name != $full_name) | [.number, if .merged_at != null then "merged" else .state end, .created_at, .closed_at, .merge_commit_sha] | @tsv' |\
+    gawk -F\\t '($4!="" && $4 >= "'${EARLIEST_PR}'") || $3 >= "'${EARLIEST_PR}'"' |\
     LC_ALL=C sort \
     > ${ANALYSISDIR}/pr_status
+
+echo "preparing commit pulls..." > /dev/stderr
+
+#drop commit pulls FROM default branch, as above
+cat ${DATADIR}/commit_pulls |\
+    jq -r -R -c  --arg default_branch $DEFAULT_BRANCH --arg full_name $REPO 'split("\t") | (.[1] | fromjson | [.[] | select(.head.ref != $default_branch or .head.repo.full_name != $full_name)])' |\
+    paste <(cat ${DATADIR}/commit_pulls | cut -f1) -\
+    > ${ANALYSISDIR}/commit_pulls
 
 echo "preparing a sample of reviewed and unreviewed commits..." > /dev/stderr
 
@@ -50,7 +63,7 @@ cat ${DATADIR}/commit_messages |\
     gawk 'BEGIN {OFS="\t"} /^__commit__ [a-f0-9]{40}$/ {commit=$2} !/^__commit__ [a-f0-9]{40}$/ {print commit, $0}' |\
     gawk -F\\t 'BEGIN {OFS="\t"} {if(match($2, /(Merge pull request #([0-9]+))|(\(#([0-9]+)\)$)/, m) > 0) { if(m[2] == "") { print m[4], $1} else { print m[2], $1}}}' |\
     LC_ALL=C sort | LC_ALL=C join -t$'\t' - ${ANALYSISDIR}/pr_status |\
-    gawk -F\\t 'BEGIN {OFS="\t"} {print $2, $1}' | LC_ALL=C sort -u\
+    gawk -F\\t 'BEGIN {OFS="\t"} {print $2, $1, "commit_message"}' | LC_ALL=C sort -u\
     >> ${ANALYSISDIR}/reviewed_commits.tmp
 
 #commits from external merge tools
@@ -58,15 +71,15 @@ cat ${DATADIR}/commit_autolinks |\
     (ag 'closes' || true) |\
     gawk -F\\t 'BEGIN {OFS="\t"} {print $2,$1}' |\
     LC_ALL=C sort | LC_ALL=C join -t$'\t' - ${ANALYSISDIR}/pr_status |\
-    gawk -F\\t 'BEGIN {OFS="\t"} {print $2,$1}' | LC_ALL=C sort -u\
+    gawk -F\\t 'BEGIN {OFS="\t"} {print $2,$1, "autolink"}' | LC_ALL=C sort -u\
     >> ${ANALYSISDIR}/reviewed_commits.tmp
 
 #commits listed in merge_commit_sha for merged PRs
 cat ${ANALYSISDIR}/pr_status |\
     (ag 'merged' || true) |\
-    gawk -F\\t 'BEGIN {OFS="\t"} {print $5,$1}' |\
+    gawk -F\\t 'BEGIN {OFS="\t"} {print $5,$1,"merge_commit"}' |\
     LC_ALL=C sort | LC_ALL=C join -t$'\t' - ${DATADIR}/commitdates |\
-    cut -f 1,2\
+    cut -f 1,2,3\
     >> ${ANALYSISDIR}/reviewed_commits.tmp
 
 #cascade review to commits with same committer and commit time
@@ -75,11 +88,11 @@ zcat ${DATADIR}/commit_graph.gz |\
     LC_ALL=C sort |\
     join -t$'\t' -a2 -o0,1.2,2.3,2.4,2.5,2.7 <(cat ${ANALYSISDIR}/reviewed_commits.tmp | LC_ALL=C sort) - |\
     sort -t$'\t' -k4r,4r -k3,3 -k6n,6n |\
-    gawk -F\\t '$2 == "" && $3 == last_ce && $4 == last_ct && last_pr != "" {printf("%s\t%s\n", $1, last_pr)} $2 == "" && $3 != last_cs || $4 != last_ct { last_pr = "" } $2 != "" {printf("%s\t%s\n", $1, $2)} $2!="" && ($3 != last_cs || $4 != last_ct) { last_pr=$2;last_ce=$3;last_ct=$4}' |\
+    gawk -F\\t -f ${DIR}/cascade_review.awk |\
     LC_ALL=C sort -u\
     > ${ANALYSISDIR}/reviewed_commits
 
-rm ${ANALYSISDIR}/reviewed_commits.tmp
+#rm ${ANALYSISDIR}/reviewed_commits.tmp
 
 
 #the complement, but during the right period
@@ -98,7 +111,7 @@ AVG_COMMENT_TIME=$(\
 
 echo "filtering LOC metadata..." > /dev/stderr
 pv ${DATADIR}/metadata.gz | zcat |\
-    gawk -F\\t '$7 >='$(date -d ${EARLIEST_PR} +%s) |\
+    gawk -F\\t '$7 >='$(date -d "${EARLIEST_PR}" +%s) |\
     gzip -c\
     > ${ANALYSISDIR}/metadata.gz
 
@@ -250,7 +263,7 @@ printf "%d\t%d\t%d\t%d\n"\
     jq -c --slurp --raw-input 'split("\t") | {"stat":"gh_merges_during_prs", "data":{"commits":(.[0]|tonumber), "gh_merges":(.[1]|tonumber), "gh_likely_merge":(.[2]|tonumber), "likely_external_merge":(.[3]|tonumber)}}'
 
 echo "comparing GH commit pull association with commit message analysis" > /dev/stderr
-cat ${DATADIR}/commit_pulls |\
+cat ${ANALYSISDIR}/commit_pulls |\
     sed -E 's/^https:\/\/api.github.com\/repos\/[^\/]*\/[^\/]*\/commits\/([a-f0-9]{40})\/pulls/\1/' |\
     LC_ALL=C sort | LC_ALL=C join -t$'\t' - <(cat ${ANALYSISDIR}/reviewed_commits ${ANALYSISDIR}/unreviewed_commits | LC_ALL=C sort) |\
     jq -r -R 'split("\t") | [.[0], (.[1] | fromjson | length), .[2]] | @tsv' |\
@@ -258,7 +271,7 @@ cat ${DATADIR}/commit_pulls |\
     gawk -M -f ${DIR}/groupstats.awk |\
     jq -c --slurp --raw-input --arg stat_name gh_rev_vs_commit_rev -f ${DIR}/gs2json.jq
 
-cat ${DATADIR}/commit_pulls |\
+cat ${ANALYSISDIR}/commit_pulls |\
     sed -E 's/^https:\/\/api.github.com\/repos\/[^\/]*\/[^\/]*\/commits\/([a-f0-9]{40})\/pulls/\1/' |\
     LC_ALL=C sort | LC_ALL=C join -t$'\t' - <(cat ${ANALYSISDIR}/reviewed_commits ${ANALYSISDIR}/unreviewed_commits | LC_ALL=C sort) |\
     jq -r -R 'split("\t") | [.[0], (.[2] as $prnumber | .[1] | fromjson | map(.number) | select(($prnumber // "0" | tonumber))|length), .[2]] | @tsv' |\

--- a/analyze
+++ b/analyze
@@ -122,13 +122,13 @@ pv ${ANALYSISDIR}/metadata.gz | zcat |\
 
 echo "dead code lifetime distribution (during analysis period)" > /dev/stderr
 pv ${ANALYSISDIR}/metadata.gz | zcat |\
-    ag 'died' | cut -f 5 | sort -n |\
+    (ag 'died' || true) | cut -f 5 | sort -n |\
     gawk -f ${DIR}/cdf.awk <(echo -n "86400_604800_1209600_2592000_5184000_7776000_15552000_31104000" | tr '_' '\n') - |\
     jq -c --slurp --raw-input --arg stat_name during_pr_code_lifetime_died_cdf -f ${DIR}/cdf2json.jq
 
 echo "live code lifetime distribution (during analysis period)" > /dev/stderr
 pv ${ANALYSISDIR}/metadata.gz | zcat |\
-    ag 'live' | cut -f 5 | sort -n |\
+    (ag 'live' || true) | cut -f 5 | sort -n |\
     gawk -f ${DIR}/cdf.awk <(echo -n "86400_604800_1209600_2592000_5184000_7776000_15552000_31104000" | tr '_' '\n') - |\
     jq -c --slurp --raw-input --arg stat_name during_pr_code_lifetime_live_cdf -f ${DIR}/cdf2json.jq
 
@@ -163,7 +163,7 @@ cat\
 echo "overlap in files for reviewed vs unreviewed commits (total commits normalized)" > /dev/stderr
 cat\
     <(cat ${ANALYSISDIR}/unreviewed_commits | gawk -v commits=$(cat ${ANALYSISDIR}/unreviewed_commits ${ANALYSISDIR}/reviewed_commits| wc -l) '{printf("%s\t%s\t%f\n", $1, "unreviewed", 1.0/commits)}')\
-    <(cat ${ANALYSISDIR}/reviewed_commits | gawk -v commits=$(cat ${ANALYSISDIR}/unreviewd_commits ${ANALYSISDIR}/reviewed_commits | wc -l) '{printf("%s\t%s\t%f\n", $1, "reviewed", 1.0/commits)}') |\
+    <(cat ${ANALYSISDIR}/reviewed_commits | gawk -v commits=$(cat ${ANALYSISDIR}/unreviewed_commits ${ANALYSISDIR}/reviewed_commits | wc -l) '{printf("%s\t%s\t%f\n", $1, "reviewed", 1.0/commits)}') |\
     LC_ALL=C sort | LC_ALL=C join -t$'\t' -\
         <(cat ${DATADIR}/filestatus | cut -f 1,4 | LC_ALL=C sort) |\
     gawk 'BEGIN {OFS="\t"} {print $4,$2,$3}' |\
@@ -176,7 +176,7 @@ cat\
     <(cat ${ANALYSISDIR}/reviewed_commits | cut -f1 | gawk '{printf("%s\treviewed\n", $1)}')\
     <(cat ${ANALYSISDIR}/unreviewed_commits | cut -f1 | gawk '{printf("%s\tunreviewed\n", $1)}') |\
     LC_ALL=C sort |\
-    LC_ALL=C join <(zcat ${ANALYSISDIR}/metadata.gz | cut -f 2,4 | LC_ALL=C sort) - |\
+    LC_ALL=C join <(pv ${ANALYSISDIR}/metadata.gz | zcat | cut -f 2,4 | LC_ALL=C sort) - |\
     LC_ALL=C sort | uniq -c |\
     gawk '{printf("%s-%s\t%d\n",$4,$3,$1)}' |\
     gawk -M -f ${DIR}/groupstats.awk |\
@@ -200,7 +200,7 @@ cat\
     <(cat ${ANALYSISDIR}/unreviewed_commits |\
         gawk -F\\t '{printf("%s\tunreviewed\n", $1)}') |\
     LC_ALL=C sort |\
-    LC_ALL=C join -t$'\t' - <(zcat ${ANALYSISDIR}/metadata.gz | cut -f 2,5 | LC_ALL=C sort) | cut -f 2,3 |\
+    LC_ALL=C join -t$'\t' - <(pv ${ANALYSISDIR}/metadata.gz | zcat | cut -f 2,5 | LC_ALL=C sort) | cut -f 2,3 |\
     gawk -M -f ${DIR}/groupstats.awk |\
     jq -c --slurp --raw-input --arg stat_name commit_review_vs_lifetime -f ${DIR}/gs2json.jq
 
@@ -210,7 +210,7 @@ cat\
     <(cat ${ANALYSISDIR}/unreviewed_commits |\
         gawk -F\\t '{printf("%s\tunreviewed\n", $1)}') |\
     LC_ALL=C sort |\
-    LC_ALL=C join -t$'\t' - <(zcat ${ANALYSISDIR}/metadata.gz | ag 'died' | cut -f 2,5 | LC_ALL=C sort) | cut -f 2,3 |\
+    LC_ALL=C join -t$'\t' - <(pv ${ANALYSISDIR}/metadata.gz | zcat | (ag 'died' || true) | cut -f 2,5 | LC_ALL=C sort) | cut -f 2,3 |\
     gawk -M -f ${DIR}/groupstats.awk |\
     jq -c --slurp --raw-input --arg stat_name commit_review_vs_lifetime_died -f ${DIR}/gs2json.jq
 
@@ -220,7 +220,7 @@ cat\
     <(cat ${ANALYSISDIR}/unreviewed_commits |\
         gawk -F\\t '{printf("%s\tunreviewed\n", $1)}') |\
     LC_ALL=C sort |\
-    LC_ALL=C join -t$'\t' - <(zcat ${ANALYSISDIR}/metadata.gz | ag 'live' | cut -f 2,5 | LC_ALL=C sort) | cut -f 2,3 |\
+    LC_ALL=C join -t$'\t' - <(pv ${ANALYSISDIR}/metadata.gz | zcat | (ag 'live' || true) | cut -f 2,5 | LC_ALL=C sort) | cut -f 2,3 |\
     gawk -M -f ${DIR}/groupstats.awk |\
     jq -c --slurp --raw-input --arg stat_name commit_review_vs_lifetime_live -f ${DIR}/gs2json.jq
 
@@ -319,3 +319,4 @@ cat ${DATADIR}/commits_with_author |\
     jq --slurp --raw-input --arg stat_name unrev_commits_proportion_by_dev_cdf -f ${DIR}/cdf2json.jq
 
 echo "done with analysis for $SPAN_DAYS days back to ${EARLIEST_PR}" > /dev/stderr
+echo

--- a/analyze
+++ b/analyze
@@ -69,13 +69,23 @@ cat ${ANALYSISDIR}/pr_status |\
     cut -f 1,2\
     >> ${ANALYSISDIR}/reviewed_commits.tmp
 
-cat ${ANALYSISDIR}/reviewed_commits.tmp | LC_ALL=C sort -u\
+#cascade review to commits with same committer and commit time
+zcat ${DATADIR}/commit_graph.gz |\
+    gawk -F\\t '{printf("%s\t%d\n", $0, NR)}' |\
+    LC_ALL=C sort |\
+    join -t$'\t' -a2 -o0,1.2,2.3,2.4,2.5,2.7 <(cat ${ANALYSISDIR}/reviewed_commits.tmp | LC_ALL=C sort) - |\
+    sort -t$'\t' -k4r,4r -k3,3 -k6n,6n |\
+    gawk -F\\t '$2 == "" && $3 == last_ce && $4 == last_ct && last_pr != "" {printf("%s\t%s\n", $1, last_pr)} $2 == "" && $3 != last_cs || $4 != last_ct { last_pr = "" } $2 != "" {printf("%s\t%s\n", $1, $2)} $2!="" && ($3 != last_cs || $4 != last_ct) { last_pr=$2;last_ce=$3;last_ct=$4}' |\
+    LC_ALL=C sort -u\
     > ${ANALYSISDIR}/reviewed_commits
+
 rm ${ANALYSISDIR}/reviewed_commits.tmp
 
+
 #the complement, but during the right period
-cat ${DATADIR}/commitdates |\
-    gawk -F\\t '$2 >='$(date -d ${EARLIEST_PR} +%s) | cut -f1 |
+zcat ${DATADIR}/commit_graph.gz |\
+    gawk -F\\t '$4 >='$(date -d ${EARLIEST_PR} +%s) | cut -f1 |\
+    LC_ALL=C sort |\
     LC_ALL=C join -v1 - ${ANALYSISDIR}/reviewed_commits \
     > ${ANALYSISDIR}/unreviewed_commits
 
@@ -86,6 +96,12 @@ AVG_COMMENT_TIME=$(\
     gawk -F\\t -i ${DIR}/reduce.awk 'BEGIN {OFS="\t";setkey("1\t2\t3");} function startrun(key) {state=$6;startts=$4;comments=0;sumtime=0;lastts=$4} function reduce(key) {if(comments>0) {print $4-lastts;} comments+=1; lastts=$4} function endrun(key) { }' |\
     gawk '{s+=$1;n+=1} END {if(n>0) { print s/n } else { print 0} }')
 
+echo "filtering LOC metadata..." > /dev/stderr
+pv ${DATADIR}/metadata.gz | zcat |\
+    gawk -F\\t '$7 >='$(date -d ${EARLIEST_PR} +%s) |\
+    gzip -c\
+    > ${ANALYSISDIR}/metadata.gz
+
 #start computing stats
 echo "doing analysis..." > /dev/stderr
 
@@ -93,29 +109,25 @@ echo "doing analysis..." > /dev/stderr
 printf "{\"stat\":\"analysis_params\", \"data\": {\"earliest_date\": \"%s\", \"span_days\": %d}}\n" ${EARLIEST_PR} ${SPAN_DAYS}
 
 echo "code birthdate summary (during analysis period)" > /dev/stderr
-pv ${DATADIR}/metadata.gz | zcat |\
-    gawk -F\\t '$7 >='$(date -d ${EARLIEST_PR} +%s) |\
+pv ${ANALYSISDIR}/metadata.gz | zcat |\
     cut -f 4,7 |\
     gawk -M -f ${DIR}/groupstats.awk |\
     jq -c --slurp --raw-input --arg stat_name during_pr_code_birthdate_summary -f ${DIR}/gs2json.jq
 
 echo "code lifetime summary (during analysis period)" > /dev/stderr
-pv ${DATADIR}/metadata.gz | zcat |\
-    gawk -F\\t '$7 >='$(date -d ${EARLIEST_PR} +%s) |\
+pv ${ANALYSISDIR}/metadata.gz | zcat |\
     cut -f4,5 |\
     gawk -M -f ${DIR}/groupstats.awk |\
     jq -c --slurp --raw-input --arg stat_name during_pr_code_lifetime_summary -f ${DIR}/gs2json.jq
 
 echo "dead code lifetime distribution (during analysis period)" > /dev/stderr
-pv ${DATADIR}/metadata.gz | zcat |\
-    gawk -F\\t '$7 >='$(date -d ${EARLIEST_PR} +%s) |\
+pv ${ANALYSISDIR}/metadata.gz | zcat |\
     ag 'died' | cut -f 5 | sort -n |\
     gawk -f ${DIR}/cdf.awk <(echo -n "86400_604800_1209600_2592000_5184000_7776000_15552000_31104000" | tr '_' '\n') - |\
     jq -c --slurp --raw-input --arg stat_name during_pr_code_lifetime_died_cdf -f ${DIR}/cdf2json.jq
 
 echo "live code lifetime distribution (during analysis period)" > /dev/stderr
-pv ${DATADIR}/metadata.gz | zcat |\
-    gawk -F\\t '$7 >='$(date -d ${EARLIEST_PR} +%s) |\
+pv ${ANALYSISDIR}/metadata.gz | zcat |\
     ag 'live' | cut -f 5 | sort -n |\
     gawk -f ${DIR}/cdf.awk <(echo -n "86400_604800_1209600_2592000_5184000_7776000_15552000_31104000" | tr '_' '\n') - |\
     jq -c --slurp --raw-input --arg stat_name during_pr_code_lifetime_live_cdf -f ${DIR}/cdf2json.jq
@@ -164,7 +176,7 @@ cat\
     <(cat ${ANALYSISDIR}/reviewed_commits | cut -f1 | gawk '{printf("%s\treviewed\n", $1)}')\
     <(cat ${ANALYSISDIR}/unreviewed_commits | cut -f1 | gawk '{printf("%s\tunreviewed\n", $1)}') |\
     LC_ALL=C sort |\
-    LC_ALL=C join <(zcat ${DATADIR}/metadata.gz | cut -f 2,4 | LC_ALL=C sort) - |\
+    LC_ALL=C join <(zcat ${ANALYSISDIR}/metadata.gz | cut -f 2,4 | LC_ALL=C sort) - |\
     LC_ALL=C sort | uniq -c |\
     gawk '{printf("%s-%s\t%d\n",$4,$3,$1)}' |\
     gawk -M -f ${DIR}/groupstats.awk |\
@@ -188,7 +200,7 @@ cat\
     <(cat ${ANALYSISDIR}/unreviewed_commits |\
         gawk -F\\t '{printf("%s\tunreviewed\n", $1)}') |\
     LC_ALL=C sort |\
-    LC_ALL=C join -t$'\t' - <(zcat ${DATADIR}/metadata.gz | cut -f 2,5 | LC_ALL=C sort) | cut -f 2,3 |\
+    LC_ALL=C join -t$'\t' - <(zcat ${ANALYSISDIR}/metadata.gz | cut -f 2,5 | LC_ALL=C sort) | cut -f 2,3 |\
     gawk -M -f ${DIR}/groupstats.awk |\
     jq -c --slurp --raw-input --arg stat_name commit_review_vs_lifetime -f ${DIR}/gs2json.jq
 
@@ -198,7 +210,7 @@ cat\
     <(cat ${ANALYSISDIR}/unreviewed_commits |\
         gawk -F\\t '{printf("%s\tunreviewed\n", $1)}') |\
     LC_ALL=C sort |\
-    LC_ALL=C join -t$'\t' - <(zcat ${DATADIR}/metadata.gz | ag 'died' | cut -f 2,5 | LC_ALL=C sort) | cut -f 2,3 |\
+    LC_ALL=C join -t$'\t' - <(zcat ${ANALYSISDIR}/metadata.gz | ag 'died' | cut -f 2,5 | LC_ALL=C sort) | cut -f 2,3 |\
     gawk -M -f ${DIR}/groupstats.awk |\
     jq -c --slurp --raw-input --arg stat_name commit_review_vs_lifetime_died -f ${DIR}/gs2json.jq
 
@@ -208,7 +220,7 @@ cat\
     <(cat ${ANALYSISDIR}/unreviewed_commits |\
         gawk -F\\t '{printf("%s\tunreviewed\n", $1)}') |\
     LC_ALL=C sort |\
-    LC_ALL=C join -t$'\t' - <(zcat ${DATADIR}/metadata.gz | ag 'live' | cut -f 2,5 | LC_ALL=C sort) | cut -f 2,3 |\
+    LC_ALL=C join -t$'\t' - <(zcat ${ANALYSISDIR}/metadata.gz | ag 'live' | cut -f 2,5 | LC_ALL=C sort) | cut -f 2,3 |\
     gawk -M -f ${DIR}/groupstats.awk |\
     jq -c --slurp --raw-input --arg stat_name commit_review_vs_lifetime_live -f ${DIR}/gs2json.jq
 

--- a/analyze
+++ b/analyze
@@ -144,6 +144,17 @@ cat\
     gawk -F\\t -i ${DIR}/reduce.awk -f ${DIR}/jaccard.awk |\
     jq -c --slurp --raw-input --arg stat_name commit_review_file_overlap -f ${DIR}/gs2json.jq
 
+echo "overlap in files for reviewed vs unreviewed commits (total commits normalized)" > /dev/stderr
+cat\
+    <(cat ${ANALYSISDIR}/unreviewed_commits | gawk -v commits=$(cat ${ANALYSISDIR}/unreviewed_commits ${ANALYSISDIR}/reviewed_commits| wc -l) '{printf("%s\t%s\t%f\n", $1, "unreviewed", 1.0/commits)}')\
+    <(cat ${ANALYSISDIR}/reviewed_commits | gawk -v commits=$(cat ${ANALYSISDIR}/unreviewd_commits ${ANALYSISDIR}/reviewed_commits | wc -l) '{printf("%s\t%s\t%f\n", $1, "reviewed", 1.0/commits)}') |\
+    LC_ALL=C sort | LC_ALL=C join -t$'\t' -\
+        <(cat ${DATADIR}/filestatus | cut -f 1,4 | LC_ALL=C sort) |\
+    gawk 'BEGIN {OFS="\t"} {print $4,$2,$3}' |\
+    LC_ALL=C sort |\
+    gawk -F\\t -i ${DIR}/reduce.awk -f ${DIR}/jaccard.awk |\
+    jq -c --slurp --raw-input --arg stat_name commit_review_file_overlap_by_commits -f ${DIR}/gs2json.jq
+
 echo "lines of code for reviewed vs unreviewed commits by outcome" > /dev/stderr
 cat\
     <(cat ${ANALYSISDIR}/reviewed_commits | cut -f1 | gawk '{printf("%s\treviewed\n", $1)}')\

--- a/analyze
+++ b/analyze
@@ -2,6 +2,7 @@
 
 #compute time-bound stats from a autodevstats datadir
 #input env vars:
+#SPAN_DAYS is the desired number of days for analysis
 #EARLIEST_PR a "Z" terminated iso-8601 date string indicating
 #   earliest date to consider in analysis
 #DATADIR the location of autodevstats data fetched and prepped
@@ -14,7 +15,7 @@ set -eu -o pipefail
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-echo "performing timespan analysis since $EARLIEST_PR" > /dev/stderr
+echo "performing timespan analysis $SPAN_DAYS days since $EARLIEST_PR" > /dev/stderr
 
 #set up state from datadir
 
@@ -87,6 +88,9 @@ AVG_COMMENT_TIME=$(\
 
 #start computing stats
 echo "doing analysis..." > /dev/stderr
+
+#record some analysis params
+printf "{\"stat\":\"analysis_params\", \"data\": {\"earliest_date\": \"%s\", \"span_days\": %d}}\n" ${EARLIEST_PR} ${SPAN_DAYS}
 
 echo "code birthdate summary (during analysis period)" > /dev/stderr
 pv ${DATADIR}/metadata.gz | zcat |\
@@ -302,4 +306,4 @@ cat ${DATADIR}/commits_with_author |\
     gawk -f ${DIR}/cdf.awk <(echo "0.1_0.25_0.5_0.75_0.8_0.9_0.95_0.99_1" | tr '_' '\n') - |\
     jq --slurp --raw-input --arg stat_name unrev_commits_proportion_by_dev_cdf -f ${DIR}/cdf2json.jq
 
-echo "done with analysis back to ${EARLIEST_PR}" > /dev/stderr
+echo "done with analysis for $SPAN_DAYS days back to ${EARLIEST_PR}" > /dev/stderr

--- a/cascade_review.awk
+++ b/cascade_review.awk
@@ -1,0 +1,33 @@
+#assume input is sorted in topological order
+#format, tab separated:
+#1. commit hash
+#2. PR number (or empty string if no PR assigned)
+#3. committer email
+#4. committer timestamp
+#5. author email
+#6. topological order number
+
+#if we ever transition to a new committer or timestamp, clear last_pr
+$3 != last_ce || $4 != last_ct {
+    last_pr = "";
+}
+
+$2 != "" {
+    #if there is a merge commit, keep it
+    printf("%s\t%s\n", $1, $2);
+
+    #if we've moved on to a different committer/timestamp
+    #we will only cascade the first PR we see in a run of last_ce/ct
+    #this allows nested reviews within an outer review
+    #e.g. in the case of a merge of a dev branch with a bunch of PRs into
+    #mainline, while avoiding mis-attributing review
+    if($3 != last_ce || $4 != last_ct) {
+        last_pr=$2;last_ce=$3;last_ct=$4;
+    }
+}
+
+$2 == "" {
+    if($3 == last_ce && $4 == last_ct && last_pr != "") {
+        printf("%s\t%s\n", $1, last_pr);
+    }
+}

--- a/statstool
+++ b/statstool
@@ -184,17 +184,16 @@ if [ -z "${DATADIR}" ] || [ ! -e "${DATADIR}" ] ; then
     echo 'https://api.github.com/repos/'${REPO}'/pulls?state=all&sort=created&direction=desc&per_page=100' | GITHUB_TOKEN=$GITHUB_TOKEN MAX_PAGES=${MAX_ALL_PR_PAGES} ALLCOMMENTS="" ${DIR}/fetch-comments.sh | gzip -c > ${DATADIR}/pulls.gz
 
     EARLIEST_PR=$(zcat ${DATADIR}/pulls.gz | jq -r '.[] | .created_at' | sort -r | tail -n1)
-    #TODO: what if last PR update was much longer ago than latest commit?
-    LATEST_DATE=$(zcat ${DATADIR}/pulls.gz | jq -r '.[] | .updated_at' | sort | tail -n1)
+    LATEST_PR=$(zcat ${DATADIR}/pulls.gz | jq -r '.[] | .updated_at' | sort | tail -n1)
+    LATEST_COMMIT=$(date -d@$(cat commitdates | cut -f 2 | sort -n | tail -n1) +%Y-%m-%dT%H:%M:%SZ --utc)
+
+    LATEST_DATE=$(printf "%s\n%s\n" "${LATEST_PR}" "${LATEST_COMMIT}" | gawk '$1 > max_date { max_date = $1 } END {print max_date}')
     MAX_SPAN_DATE=$(date @$(( $(date -d "$LATEST_DATE" +%s) - $(( $MAX_SPAN_DAYS * 86400 )) )) +%Y-%m-%dT%H:%M:%SZ --utc)
-    LONG_SPAN_DATE=$(date @$(( $(date -d "$LATEST_DATE" +%s) - $(( $LONG_SPAN_DAYS * 86400 )) )) +%Y-%m-%dT%H:%M:%SZ --utc)
-    SHORT_SPAN_DATE=$(date @$(( $(date -d "$LATEST_DATE" +%s) - $(( $SHORT_SPAN_DAYS * 86400 )) )) +%Y-%m-%dT%H:%M:%SZ --utc)
 
     printf "EARLIEST_PR\t%s" $EARLIEST_PR >> ${DATADIR}/times.tsv
-    printf "LATEST_DATE\t%s" $LATEST_DATE >> ${DATADIR}/times.tsv
+    printf "LATEST_PR\t%s" $LATEST_PR >> ${DATADIR}/times.tsv
+    printf "LATEST_COMMIT\t%s" $LATEST_COMMIT >> ${DATADIR}/times.tsv
     printf "MAX_SPAN_DATE\t%s" $MAX_SPAN_DATE >> ${DATADIR}/times.tsv
-    printf "LONG_SPAN_DATE\t%s" $LONG_SPAN_DATE >> ${DATADIR}/times.tsv
-    printf "SHORT_SPAN_DATE\t%s" $SHORT_SPAN_DATE >> ${DATADIR}/times.tsv
 
     #limit to max span of analysis
     if [[ "$EARLIEST_PR" < "$MAX_SPAN_DATE" ]]; then
@@ -262,10 +261,11 @@ elif [ -d "${DATADIR}" ]; then
 
     #catch up on some state we might need
     EARLIEST_PR=$(zcat ${DATADIR}/pulls.gz | jq -r '.[] | .created_at' | sort -r | tail -n1)
-    LATEST_DATE=$(zcat ${DATADIR}/pulls.gz | jq -r '.[] | .updated_at' | sort | tail -n1)
+    LATEST_PR=$(zcat ${DATADIR}/pulls.gz | jq -r '.[] | .updated_at' | sort | tail -n1)
+    LATEST_COMMIT=$(date -d@$(cat commitdates | cut -f 2 | sort -n | tail -n1) +%Y-%m-%dT%H:%M:%SZ --utc)
+
+    LATEST_DATE=$(printf "%s\n%s\n" "${LATEST_PR}" "${LATEST_COMMIT}" | gawk '$1 > max_date { max_date = $1 } END {print max_date}')
     MAX_SPAN_DATE=$(date @$(( $(date -d "$LATEST_DATE" +%s) - $(( $MAX_SPAN_DAYS * 86400 )) )) +%Y-%m-%dT%H:%M:%SZ --utc)
-    LONG_SPAN_DATE=$(date @$(( $(date -d "$LATEST_DATE" +%s) - $(( $LONG_SPAN_DAYS * 86400 )) )) +%Y-%m-%dT%H:%M:%SZ --utc)
-    SHORT_SPAN_DATE=$(date @$(( $(date -d "$LATEST_DATE" +%s) - $(( $SHORT_SPAN_DAYS * 86400 )) )) +%Y-%m-%dT%H:%M:%SZ --utc)
 
     #limit to max span of analysis
     if [[ "$EARLIEST_PR" < "$MAX_SPAN_DATE" ]]; then
@@ -275,6 +275,9 @@ else
     echo "${DATADIR} exists but isn't a directory, run without that param and we'll create a directory to hold data"
     exit 1
 fi
+
+LONG_SPAN_DATE=$(date @$(( $(date -d "$LATEST_DATE" +%s) - $(( $LONG_SPAN_DAYS * 86400 )) )) +%Y-%m-%dT%H:%M:%SZ --utc)
+SHORT_SPAN_DATE=$(date @$(( $(date -d "$LATEST_DATE" +%s) - $(( $SHORT_SPAN_DAYS * 86400 )) )) +%Y-%m-%dT%H:%M:%SZ --utc)
 
 #truncate stats time file
 > ${DATADIR}/statstimes.tsv

--- a/statstool
+++ b/statstool
@@ -20,15 +20,11 @@ COMMIT_PR_SAMPLESIZE=200
 
 #an outer bound for how many pages of PRs we'll try to fetch
 #TODO: we'll need to expand this to more reliably capture 1 year of history
-MAX_ALL_PR_PAGES=20
-#an outer bound for how much data we'll pull from github, 2 years
+MAX_ALL_PR_PAGES=60
+#an outer bound for how much data we'll pull from github, 3 years
 MAX_SPAN_DAYS=730
-
 #we'll run sets of time-bound analyses:
-#long span = 1 year
-LONG_SPAN_DAYS=365
-#short span = 6 months
-SHORT_SPAN_DAYS=183
+SPAN_DAYS="183 365 730 1460"
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
@@ -172,6 +168,7 @@ if [ -z "${DATADIR}" ] || [ ! -e "${DATADIR}" ] ; then
     echo "preparing commit messages..."
     git log "${DEFAULT_BRANCH}" --first-parent --format='__commit__ %H%x0A%B' > ${DATADIR}/commit_messages
     git log "${DEFAULT_BRANCH}" --format='%H%x09%ae' | LC_ALL=C sort > ${DATADIR}/commits_with_author
+    git log "${DEFAULT_BRANCH}" --topo-order --format='%H%x09%P%x09%ce%x09%ct%x09%ae%x09%at' | gzip -c > ${DATADIR}/commit_graph.gz
     echo "done."
 
 
@@ -185,7 +182,7 @@ if [ -z "${DATADIR}" ] || [ ! -e "${DATADIR}" ] ; then
 
     EARLIEST_PR=$(zcat ${DATADIR}/pulls.gz | jq -r '.[] | .created_at' | sort -r | tail -n1)
     LATEST_PR=$(zcat ${DATADIR}/pulls.gz | jq -r '.[] | .updated_at' | sort | tail -n1)
-    LATEST_COMMIT=$(date -d@$(cat commitdates | cut -f 2 | sort -n | tail -n1) --utc +%Y-%m-%dT%H:%M:%SZ)
+    LATEST_COMMIT=$(date -d@$(cat ${DATADIR}/commitdates | cut -f 2 | sort -n | tail -n1) --utc +%Y-%m-%dT%H:%M:%SZ)
 
     LATEST_DATE=$(printf "%s\n%s\n" "${LATEST_PR}" "${LATEST_COMMIT}" | gawk '$1 > max_date { max_date = $1 } END {print max_date}')
     MAX_SPAN_DATE=$(date -d@$(( $(date -d "$LATEST_DATE" +%s) - $(( $MAX_SPAN_DAYS * 86400 )) )) --utc +%Y-%m-%dT%H:%M:%SZ)
@@ -262,9 +259,7 @@ elif [ -d "${DATADIR}" ]; then
     #catch up on some state we might need
     EARLIEST_PR=$(zcat ${DATADIR}/pulls.gz | jq -r '.[] | .created_at' | sort -r | tail -n1)
     LATEST_PR=$(zcat ${DATADIR}/pulls.gz | jq -r '.[] | .updated_at' | sort | tail -n1)
-    echo "foo"
-    LATEST_COMMIT=$(date -d@$(cat commitdates | cut -f 2 | sort -n | tail -n1) --utc +%Y-%m-%dT%H:%M:%SZ)
-    echo "bar"
+    LATEST_COMMIT=$(date -d@$(cat ${DATADIR}/commitdates | cut -f 2 | sort -n | tail -n1) --utc +%Y-%m-%dT%H:%M:%SZ)
 
     LATEST_DATE=$(printf "%s\n%s\n" "${LATEST_PR}" "${LATEST_COMMIT}" | gawk '$1 > max_date { max_date = $1 } END {print max_date}')
     MAX_SPAN_DATE=$(date -d@$(( $(date -d "$LATEST_DATE" +%s) - $(( $MAX_SPAN_DAYS * 86400 )) )) --utc +%Y-%m-%dT%H:%M:%SZ)
@@ -674,13 +669,22 @@ cat ${DATADIR}/pr_status |\
     cut -f 1,2\
     >> ${DATADIR}/reviewed_commits.tmp
 
-cat ${DATADIR}/reviewed_commits.tmp | LC_ALL=C sort -u\
+#cascade review to commits with same committer and commit time
+zcat ${DATADIR}/commit_graph.gz |\
+    gawk -F\\t '{printf("%s\t%d\n", $0, NR)}' |\
+    LC_ALL=C sort |\
+    join -t$'\t' -a2 -o0,1.2,2.3,2.4,2.5,2.7 <(cat ${DATADIR}/reviewed_commits.tmp | LC_ALL=C sort) - |\
+    sort -t$'\t' -k4r,4r -k3,3 -k6n,6n |\
+    gawk -F\\t '$2 == "" && $3 == last_ce && $4 == last_ct && last_pr != "" {printf("%s\t%s\n", $1, last_pr)} $2 == "" && $3 != last_cs || $4 != last_ct { last_pr = "" } $2 != "" {printf("%s\t%s\n", $1, $2)} $2!="" && ($3 != last_cs || $4 != last_ct) { last_pr=$2;last_ce=$3;last_ct=$4}' |\
+    LC_ALL=C sort -u\
     > ${DATADIR}/reviewed_commits
+
 rm ${DATADIR}/reviewed_commits.tmp
 
 #the complement, but during the right period
-cat ${DATADIR}/commitdates |\
-    gawk -F\\t '$2 >='$(date -d ${EARLIEST_PR} +%s) | cut -f1 |
+zcat ${DATADIR}/commit_graph.gz |\
+    gawk -F\\t '$4 >='$(date -d ${EARLIEST_PR} +%s) | cut -f1 |\
+    LC_ALL=C sort |\
     LC_ALL=C join -v1 - ${DATADIR}/reviewed_commits \
     > ${DATADIR}/unreviewed_commits
 
@@ -880,7 +884,7 @@ echo
 echo "computing timespan limited stats..."
 echo
 
-for span in $SHORT_SPAN_DAYS $LONG_SPAN_DAYS $MAX_SPAN_DAYS; do
+for span in $SPAN_DAYS; do
     SPAN_DATE=$(date -d@$(( $(date -d "$LATEST_DATE" +%s) - $(( $span * 86400 )) )) --utc +%Y-%m-%dT%H:%M:%SZ)
     SPAN_DAYS=$span EARLIEST_PR=$SPAN_DATE DATADIR=$DATADIR ${DIR}/analyze |\
         jq -c --slurp '{"stat": "analysis_days_'${span}'", "data": . }'\

--- a/statstool
+++ b/statstool
@@ -26,8 +26,8 @@ MAX_ALL_PR_PAGES=60
 #an outer bound for how much data we'll pull from github, 3 years
 MAX_SPAN_DAYS=730
 #we'll run sets of time-bound analyses:
-#SPAN_DAYS="183 365 730 1460"
-SPAN_DAYS=365
+SPAN_DAYS="183 365 730 1460"
+#SPAN_DAYS=365
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 

--- a/statstool
+++ b/statstool
@@ -20,11 +20,14 @@ COMMIT_PR_SAMPLESIZE=200
 
 #an outer bound for how many pages of PRs we'll try to fetch
 #TODO: we'll need to expand this to more reliably capture 1 year of history
+#this is enough to hopefully capture ~1 year of PRs even for very active repos
+#the vast majority (>95%) of OSS benchmark repos are captured by just 20 pages
 MAX_ALL_PR_PAGES=60
 #an outer bound for how much data we'll pull from github, 3 years
 MAX_SPAN_DAYS=730
 #we'll run sets of time-bound analyses:
-SPAN_DAYS="183 365 730 1460"
+#SPAN_DAYS="183 365 730 1460"
+SPAN_DAYS=365
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
@@ -184,22 +187,36 @@ if [ -z "${DATADIR}" ] || [ ! -e "${DATADIR}" ] ; then
     LATEST_PR=$(zcat ${DATADIR}/pulls.gz | jq -r '.[] | .updated_at' | sort | tail -n1)
     LATEST_COMMIT=$(date -d@$(cat ${DATADIR}/commitdates | cut -f 2 | sort -n | tail -n1) --utc +%Y-%m-%dT%H:%M:%SZ)
 
-    LATEST_DATE=$(printf "%s\n%s\n" "${LATEST_PR}" "${LATEST_COMMIT}" | gawk '$1 > max_date { max_date = $1 } END {print max_date}')
+    #tried using the latest of commit and PR, but commit makes more sense
+    #for some inactive repos PRs might still get comments long after the last commit
+    #LATEST_DATE=$(printf "%s\n%s\n" "${LATEST_PR}" "${LATEST_COMMIT}" | gawk '$1 > max_date { max_date = $1 } END {print max_date}')
+    LATEST_DATE=$LATEST_COMMIT
     MAX_SPAN_DATE=$(date -d@$(( $(date -d "$LATEST_DATE" +%s) - $(( $MAX_SPAN_DAYS * 86400 )) )) --utc +%Y-%m-%dT%H:%M:%SZ)
 
-    printf "EARLIEST_PR\t%s" $EARLIEST_PR >> ${DATADIR}/times.tsv
-    printf "LATEST_PR\t%s" $LATEST_PR >> ${DATADIR}/times.tsv
-    printf "LATEST_COMMIT\t%s" $LATEST_COMMIT >> ${DATADIR}/times.tsv
-    printf "MAX_SPAN_DATE\t%s" $MAX_SPAN_DATE >> ${DATADIR}/times.tsv
+    printf "EARLIEST_PR\t%d\n" $(date -d $EARLIEST_PR +%s) >> ${DATADIR}/times.tsv
+    printf "LATEST_PR\t%d\n" $(date -d $LATEST_PR +%s) >> ${DATADIR}/times.tsv
+    printf "LATEST_COMMIT\t%d\n" $(date -d $LATEST_COMMIT +%s) >> ${DATADIR}/times.tsv
+    printf "MAX_SPAN_DATE\t%d\n" $(date -d $MAX_SPAN_DATE +%s) >> ${DATADIR}/times.tsv
 
     #limit to max span of analysis
-    if [[ "$EARLIEST_PR" < "$MAX_SPAN_DATE" ]]; then
-        EARLIEST_PR=$MAX_SPAN_DATE
+    EARLIEST_DATE=$EARLIEST_PR
+    if [[ "$EARLIEST_DATE" < "$MAX_SPAN_DATE" ]]; then
+        EARLIEST_DATE=$MAX_SPAN_DATE
     fi
 
-    echo 'https://api.github.com/repos/'${REPO}'/pulls/comments?since='${EARLIEST_PR}'&per_page=100' | GITHUB_TOKEN=$GITHUB_TOKEN ALLCOMMENTS="" ${DIR}/fetch-comments.sh | gzip -c > ${DATADIR}/pull-comments.gz
-    echo 'https://api.github.com/repos/'${REPO}'/issues/comments?since='${EARLIEST_PR}'&per_page=100' | GITHUB_TOKEN=$GITHUB_TOKEN ALLCOMMENTS="" ${DIR}/fetch-comments.sh | gzip -c > ${DATADIR}/issue-comments.gz
-    echo 'https://api.github.com/repos/'${REPO}'/issues?since='${EARLIEST_PR}'&state=all&per_page=100' | GITHUB_TOKEN=$GITHUB_TOKEN ALLCOMMENTS="" ${DIR}/fetch-comments.sh | gzip -c > ${DATADIR}/issues.gz
+    echo 'https://api.github.com/repos/'${REPO}'/pulls/comments?since='${EARLIEST_DATE}'&sort=created&order=desc&per_page=100' | GITHUB_TOKEN=$GITHUB_TOKEN ALLCOMMENTS="" ${DIR}/fetch-comments.sh | gzip -c > ${DATADIR}/pull-comments.gz
+    #TODO: issue comments might be limited to just 400 pages, need to make sure we get the issue comments for the relevant PRs
+    echo 'https://api.github.com/repos/'${REPO}'/issues/comments?since='${EARLIEST_DATE}'&sort=created&order=desc&per_page=100' | GITHUB_TOKEN=$GITHUB_TOKEN ALLCOMMENTS="" ${DIR}/fetch-comments.sh | gzip -c > ${DATADIR}/issue-comments.gz
+    #if [ $(zcat ${DATADIR}/issue-comments.gz | zcat | wc -l) -eq 400 ]; then
+        #TODO: what to do if we get cut off on comments?
+        #A. replace with pull-by-pull and live with not having non-PR comments
+        #B. repeatedly recompute latest date and ask for more since then
+        #C. compute diff on PRs and fetch missing (maybe handle the edge case?)
+        #D. ignore it? maybe measure how often this happens?
+    #fi
+    #zcat ${DATADIR}/pulls.gz | jq -r '.[] | .comments_url' | sed 's/$/?per_page=100/' | GITHUB_TOKEN=$GITHUB_TOKEN ALLCOMMENTS="" SILENT=true ${DIR}/fetch-comments.sh | pv -l -s $(zcat ${DATADIR}/pulls.gz | jq -r '.[] | .comments_url' | wc -l) | gzip -c > ${DATADIR}/issue-comments.gz
+    echo 'https://api.github.com/repos/'${REPO}'/issues?since='${EARLIEST_DATE}'&state=all&sort=created&order=desc&per_page=100' | GITHUB_TOKEN=$GITHUB_TOKEN ALLCOMMENTS="" ${DIR}/fetch-comments.sh | gzip -c > ${DATADIR}/issues.gz
+    #zcat ${DATADIR}/pulls.gz | jq -r '.[] | .issue_url' | GITHUB_TOKEN=$GITHUB_TOKEN ALLCOMMENTS="" SILENT=true ${DIR}/fetch-comments.sh | pv -l -s $(zcat ${DATADIR}/pulls.gz | jq -r '.[] | .issue_url' | wc -l) | gzip -c > ${DATADIR}/issue.gz
 
     #TODO: we don't use this data anywhere, maybe don't fetch it?
     #echo 'https://api.github.com/repos/'${REPO}'/comments?per_page=100' | GITHUB_TOKEN=$GITHUB_TOKEN ALLCOMMENTS="" ${DIR}/fetch-comments.sh | gzip -c > ${DATADIR}/commit-comments.gz
@@ -212,7 +229,7 @@ if [ -z "${DATADIR}" ] || [ ! -e "${DATADIR}" ] ; then
     echo "checking with GitHub how a sample of commits relate to pulls..."
     starttime=$(date +%s)
     cat ${DATADIR}/commitdates |\
-        gawk -vrepo=${REPO} -vearliest=$(date -d "${EARLIEST_PR}" +%s) -F\\t '$2>=earliest {printf("https://api.github.com/repos/%s/commits/%s/pulls\n", repo, $1)}' |\
+        gawk -vrepo=${REPO} -vearliest=$(date -d "${EARLIEST_DATE}" +%s) -F\\t '$2>=earliest {printf("https://api.github.com/repos/%s/commits/%s/pulls\n", repo, $1)}' |\
         sort -R | tail -n${COMMIT_PR_SAMPLESIZE} |\
         GITHUB_TOKEN=$GITHUB_TOKEN HEADER_ACCEPT="application/vnd.github.groot-preview+json" PREFIX_URL=true SILENT=true ${DIR}/fetch-comments.sh | pv -l -s200 \
         > ${DATADIR}/commit_pulls
@@ -261,12 +278,20 @@ elif [ -d "${DATADIR}" ]; then
     LATEST_PR=$(zcat ${DATADIR}/pulls.gz | jq -r '.[] | .updated_at' | sort | tail -n1)
     LATEST_COMMIT=$(date -d@$(cat ${DATADIR}/commitdates | cut -f 2 | sort -n | tail -n1) --utc +%Y-%m-%dT%H:%M:%SZ)
 
-    LATEST_DATE=$(printf "%s\n%s\n" "${LATEST_PR}" "${LATEST_COMMIT}" | gawk '$1 > max_date { max_date = $1 } END {print max_date}')
+    #tried using the latest of commit and PR, but commit makes more sense
+    #for some inactive repos PRs might still get comments long after the last commit
+    #LATEST_DATE=$(printf "%s\n%s\n" "${LATEST_PR}" "${LATEST_COMMIT}" | gawk '$1 > max_date { max_date = $1 } END {print max_date}')
+    LATEST_DATE=$LATEST_COMMIT
     MAX_SPAN_DATE=$(date -d@$(( $(date -d "$LATEST_DATE" +%s) - $(( $MAX_SPAN_DAYS * 86400 )) )) --utc +%Y-%m-%dT%H:%M:%SZ)
 
     #limit to max span of analysis
-    if [[ "$EARLIEST_PR" < "$MAX_SPAN_DATE" ]]; then
-        EARLIEST_PR=$MAX_SPAN_DATE
+    EARLIEST_DATE=$EARLIEST_PR
+    if [[ "$EARLIEST_DATE" < "$MAX_SPAN_DATE" ]]; then
+        EARLIEST_DATE=$MAX_SPAN_DATE
+    fi
+
+    if [ -z "$DEFAULT_BRANCH" ]; then
+        DEFAULT_BRANCH=$(cat ${DATADIR}/repo | jq -r '.default_branch')
     fi
 else
     echo "${DATADIR} exists but isn't a directory, run without that param and we'll create a directory to hold data"
@@ -414,7 +439,7 @@ printf "%d\t%d\t%d\t%d\n"\
 
 echo "PR merge commits during analysis period"
 printf "%d\t%d\t%d\t%d\n"\
-    $(cat ${DATADIR}/commit_messages | ag '__commit__ [a-f0-9]{40}' | gawk '{print $2}' | LC_ALL=C sort | LC_ALL=C join - ${DATADIR}/commitdates | gawk '$2 >= '$(date -d ${EARLIEST_PR} +%s) | wc -l)\
+    $(cat ${DATADIR}/commit_messages | ag '__commit__ [a-f0-9]{40}' | gawk '{print $2}' | LC_ALL=C sort | LC_ALL=C join - ${DATADIR}/commitdates | gawk '$2 >= '$(date -d ${EARLIEST_DATE} +%s) | wc -l)\
     $(cat ${DATADIR}/commit_messages | (grep -E -o 'Merge pull request #[0-9]+ from' || true) | grep -o '[0-9]*' | LC_ALL=C sort | LC_ALL=C join - ${DATADIR}/pr_status | wc -l)\
     $(cat ${DATADIR}/commit_messages | (grep -E -A1 '^__commit__ [a-f0-9]{40}$' || true) | (grep -E -o ' \(#[0-9]+\)$' || true) | grep -o '[0-9]*' | LC_ALL=C sort | LC_ALL=C join - ${DATADIR}/pr_status | wc -l)\
     $(cat ${DATADIR}/commit_autolinks | grep 'close' | cut -f 2 | LC_ALL=C sort | LC_ALL=C join - ${DATADIR}/pr_status | wc -l) |\
@@ -683,7 +708,7 @@ rm ${DATADIR}/reviewed_commits.tmp
 
 #the complement, but during the right period
 zcat ${DATADIR}/commit_graph.gz |\
-    gawk -F\\t '$4 >='$(date -d ${EARLIEST_PR} +%s) | cut -f1 |\
+    gawk -F\\t '$4 >='$(date -d ${EARLIEST_DATE} +%s) | cut -f1 |\
     LC_ALL=C sort |\
     LC_ALL=C join -v1 - ${DATADIR}/reviewed_commits \
     > ${DATADIR}/unreviewed_commits
@@ -886,7 +911,10 @@ echo
 
 for span in $SPAN_DAYS; do
     SPAN_DATE=$(date -d@$(( $(date -d "$LATEST_DATE" +%s) - $(( $span * 86400 )) )) --utc +%Y-%m-%dT%H:%M:%SZ)
-    SPAN_DAYS=$span EARLIEST_PR=$SPAN_DATE DATADIR=$DATADIR ${DIR}/analyze |\
+    if [[ "$SPAN_DATE" < "$EARLIEST_PR" ]]; then
+        SPAN_DATE=$EARLIEST_PR
+    fi
+    SPAN_DAYS=$span EARLIEST_PR=$SPAN_DATE DATADIR=$DATADIR DEFAULT_BRANCH=${DEFAULT_BRANCH} ${DIR}/analyze |\
         jq -c --slurp '{"stat": "analysis_days_'${span}'", "data": . }'\
         >> ${DATADIR}/stats.json
 done

--- a/statstool
+++ b/statstool
@@ -882,7 +882,7 @@ echo
 
 for span in $SHORT_SPAN_DAYS $LONG_SPAN_DAYS $MAX_SPAN_DAYS; do
     SPAN_DATE=$(date -d@$(( $(date -d "$LATEST_DATE" +%s) - $(( $span * 86400 )) )) --utc +%Y-%m-%dT%H:%M:%SZ)
-    EARLIEST_PR=$SPAN_DATE DATADIR=$DATADIR ${DIR}/analyze |\
+    SPAN_DAYS=$span EARLIEST_PR=$SPAN_DATE DATADIR=$DATADIR ${DIR}/analyze |\
         jq -c --slurp '{"stat": "analysis_days_'${span}'", "data": . }'\
         >> ${DATADIR}/stats.json
 done

--- a/statstool
+++ b/statstool
@@ -185,10 +185,10 @@ if [ -z "${DATADIR}" ] || [ ! -e "${DATADIR}" ] ; then
 
     EARLIEST_PR=$(zcat ${DATADIR}/pulls.gz | jq -r '.[] | .created_at' | sort -r | tail -n1)
     LATEST_PR=$(zcat ${DATADIR}/pulls.gz | jq -r '.[] | .updated_at' | sort | tail -n1)
-    LATEST_COMMIT=$(date -d@$(cat commitdates | cut -f 2 | sort -n | tail -n1) +%Y-%m-%dT%H:%M:%SZ --utc)
+    LATEST_COMMIT=$(date -d@$(cat commitdates | cut -f 2 | sort -n | tail -n1) --utc +%Y-%m-%dT%H:%M:%SZ)
 
     LATEST_DATE=$(printf "%s\n%s\n" "${LATEST_PR}" "${LATEST_COMMIT}" | gawk '$1 > max_date { max_date = $1 } END {print max_date}')
-    MAX_SPAN_DATE=$(date @$(( $(date -d "$LATEST_DATE" +%s) - $(( $MAX_SPAN_DAYS * 86400 )) )) +%Y-%m-%dT%H:%M:%SZ --utc)
+    MAX_SPAN_DATE=$(date -d@$(( $(date -d "$LATEST_DATE" +%s) - $(( $MAX_SPAN_DAYS * 86400 )) )) --utc +%Y-%m-%dT%H:%M:%SZ)
 
     printf "EARLIEST_PR\t%s" $EARLIEST_PR >> ${DATADIR}/times.tsv
     printf "LATEST_PR\t%s" $LATEST_PR >> ${DATADIR}/times.tsv
@@ -262,10 +262,12 @@ elif [ -d "${DATADIR}" ]; then
     #catch up on some state we might need
     EARLIEST_PR=$(zcat ${DATADIR}/pulls.gz | jq -r '.[] | .created_at' | sort -r | tail -n1)
     LATEST_PR=$(zcat ${DATADIR}/pulls.gz | jq -r '.[] | .updated_at' | sort | tail -n1)
-    LATEST_COMMIT=$(date -d@$(cat commitdates | cut -f 2 | sort -n | tail -n1) +%Y-%m-%dT%H:%M:%SZ --utc)
+    echo "foo"
+    LATEST_COMMIT=$(date -d@$(cat commitdates | cut -f 2 | sort -n | tail -n1) --utc +%Y-%m-%dT%H:%M:%SZ)
+    echo "bar"
 
     LATEST_DATE=$(printf "%s\n%s\n" "${LATEST_PR}" "${LATEST_COMMIT}" | gawk '$1 > max_date { max_date = $1 } END {print max_date}')
-    MAX_SPAN_DATE=$(date @$(( $(date -d "$LATEST_DATE" +%s) - $(( $MAX_SPAN_DAYS * 86400 )) )) +%Y-%m-%dT%H:%M:%SZ --utc)
+    MAX_SPAN_DATE=$(date -d@$(( $(date -d "$LATEST_DATE" +%s) - $(( $MAX_SPAN_DAYS * 86400 )) )) --utc +%Y-%m-%dT%H:%M:%SZ)
 
     #limit to max span of analysis
     if [[ "$EARLIEST_PR" < "$MAX_SPAN_DATE" ]]; then
@@ -276,8 +278,6 @@ else
     exit 1
 fi
 
-LONG_SPAN_DATE=$(date @$(( $(date -d "$LATEST_DATE" +%s) - $(( $LONG_SPAN_DAYS * 86400 )) )) +%Y-%m-%dT%H:%M:%SZ --utc)
-SHORT_SPAN_DATE=$(date @$(( $(date -d "$LATEST_DATE" +%s) - $(( $SHORT_SPAN_DAYS * 86400 )) )) +%Y-%m-%dT%H:%M:%SZ --utc)
 
 #truncate stats time file
 > ${DATADIR}/statstimes.tsv
@@ -876,6 +876,17 @@ cat ${DATADIR}/pr_sample_commits_parsed |\
     jq -c --slurp --raw-input --arg stat_name commit_relative_age -f ${DIR}/gs2json.jq\
     >> ${DATADIR}/stats.json
 
+echo
+echo "computing timespan limited stats..."
+echo
+
+for span in $SHORT_SPAN_DAYS $LONG_SPAN_DAYS $MAX_SPAN_DAYS; do
+    SPAN_DATE=$(date -d@$(( $(date -d "$LATEST_DATE" +%s) - $(( $span * 86400 )) )) --utc +%Y-%m-%dT%H:%M:%SZ)
+    EARLIEST_PR=$SPAN_DATE DATADIR=$DATADIR ${DIR}/analyze |\
+        jq -c --slurp '{"stat": "analysis_days_'${span}'", "data": . }'\
+        >> ${DATADIR}/stats.json
+done
+
 compute_stats_time=$(( $(date +%s) - ${starttime}))
 printf "stats_time\t%f\n" $compute_stats_time >> ${DATADIR}/statstimes.tsv
 cat ${DATADIR}/statstimes.tsv |\
@@ -884,8 +895,6 @@ cat ${DATADIR}/statstimes.tsv |\
 
 echo "done computing stats in in ${compute_stats_time}s."
 echo
-
-
 
 echo "Thank You! Please email back the file ${DATADIR}/stats.json"
 

--- a/statstool
+++ b/statstool
@@ -619,37 +619,6 @@ pv ${DATADIR}/metadata.gz | zcat | ag 'live' | cut -f 5 | sort -n |\
     jq -c --slurp --raw-input --arg stat_name code_lifetime_live_cdf -f ${DIR}/cdf2json.jq\
     >> ${DATADIR}/stats.json
 
-echo "code birthdate summary (during analysis period)"
-pv ${DATADIR}/metadata.gz | zcat |\
-    gawk -F\\t '$7 >='$(date -d ${EARLIEST_PR} +%s)
-    cut -f 4,7 |\
-    gawk -M -f ${DIR}/groupstats.awk |\
-    jq -c --slurp --raw-input --arg stat_name during_pr_code_birthdate_summary -f ${DIR}/gs2json.jq\
-    >> ${DATADIR}/stats.json
-
-echo "code lifetime summary (during analysis period)"
-pv ${DATADIR}/metadata.gz | zcat |\
-    gawk -F\\t '$7 >='$(date -d ${EARLIEST_PR} +%s)
-    cut -f4,5 |\
-    gawk -M -f ${DIR}/groupstats.awk |\
-    jq -c --slurp --raw-input --arg stat_name during_pr_code_lifetime_summary -f ${DIR}/gs2json.jq\
-    >> ${DATADIR}/stats.json
-
-echo "dead code lifetime distribution (during analysis period)"
-pv ${DATADIR}/metadata.gz | zcat |\
-    gawk -F\\t '$7 >='$(date -d ${EARLIEST_PR} +%s) |\
-    ag 'died' | cut -f 5 | sort -n |\
-    gawk -f ${DIR}/cdf.awk <(echo -n "86400_604800_1209600_2592000_5184000_7776000_15552000_31104000" | tr '_' '\n') - |\
-    jq -c --slurp --raw-input --arg stat_name during_pr_code_lifetime_died_cdf -f ${DIR}/cdf2json.jq\
-    >> ${DATADIR}/stats.json
-
-echo "live code lifetime distribution (during analysis period)"
-pv ${DATADIR}/metadata.gz | zcat |\
-    gawk -F\\t '$7 >='$(date -d ${EARLIEST_PR} +%s) |\
-    ag 'live' | cut -f 5 | sort -n |\
-    gawk -f ${DIR}/cdf.awk <(echo -n "86400_604800_1209600_2592000_5184000_7776000_15552000_31104000" | tr '_' '\n') - |\
-    jq -c --slurp --raw-input --arg stat_name during_pr_code_lifetime_live_cdf -f ${DIR}/cdf2json.jq\
-    >> ${DATADIR}/stats.json
 
 #TODO: code lifetime stats per file
 
@@ -826,6 +795,7 @@ cat\
     gawk -M -f ${DIR}/groupstats.awk |\
     jq -c --slurp --raw-input --arg stat_name commit_review_vs_lifetime_live -f ${DIR}/gs2json.jq\
     >> ${DATADIR}/stats.json
+
 echo "lines of code for reviewed vs unreviewed commits"
 cat\
     <(cat ${DATADIR}/reviewed_commits | cut -f1 | gawk '{printf("%s\treviewed\n", $1)}')\

--- a/statstool
+++ b/statstool
@@ -17,7 +17,18 @@ set -eu -o pipefail
 
 PR_SAMPLESIZE=250
 COMMIT_PR_SAMPLESIZE=200
+
+#an outer bound for how many pages of PRs we'll try to fetch
+#TODO: we'll need to expand this to more reliably capture 1 year of history
 MAX_ALL_PR_PAGES=20
+#an outer bound for how much data we'll pull from github, 2 years
+MAX_SPAN_DAYS=730
+
+#we'll run sets of time-bound analyses:
+#long span = 1 year
+LONG_SPAN_DAYS=365
+#short span = 6 months
+SHORT_SPAN_DAYS=183
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
@@ -98,6 +109,13 @@ if [ -z "${DATADIR}" ] || [ ! -e "${DATADIR}" ] ; then
     echo "we'll write data to ${DATADIR}"
     echo
 
+    #truncate timing data
+    > ${DATADIR}/times.tsv
+
+    #record when we start pulling data
+    #this can be used as a good timestamp for when data collection happened
+    data_pull_start_time=$(date +%s)
+    printf "data_pull_start_time\t%d\n" $data_pull_start_time >> ${DATADIR}/times.tsv
 
     echo "checking access to github for this repo..."
     REPO_URL="https://api.github.com/repos/${REPO}"
@@ -166,6 +184,22 @@ if [ -z "${DATADIR}" ] || [ ! -e "${DATADIR}" ] ; then
     echo 'https://api.github.com/repos/'${REPO}'/pulls?state=all&sort=created&direction=desc&per_page=100' | GITHUB_TOKEN=$GITHUB_TOKEN MAX_PAGES=${MAX_ALL_PR_PAGES} ALLCOMMENTS="" ${DIR}/fetch-comments.sh | gzip -c > ${DATADIR}/pulls.gz
 
     EARLIEST_PR=$(zcat ${DATADIR}/pulls.gz | jq -r '.[] | .created_at' | sort -r | tail -n1)
+    #TODO: what if last PR update was much longer ago than latest commit?
+    LATEST_DATE=$(zcat ${DATADIR}/pulls.gz | jq -r '.[] | .updated_at' | sort | tail -n1)
+    MAX_SPAN_DATE=$(date @$(( $(date -d "$LATEST_DATE" +%s) - $(( $MAX_SPAN_DAYS * 86400 )) )) +%Y-%m-%dT%H:%M:%SZ --utc)
+    LONG_SPAN_DATE=$(date @$(( $(date -d "$LATEST_DATE" +%s) - $(( $LONG_SPAN_DAYS * 86400 )) )) +%Y-%m-%dT%H:%M:%SZ --utc)
+    SHORT_SPAN_DATE=$(date @$(( $(date -d "$LATEST_DATE" +%s) - $(( $SHORT_SPAN_DAYS * 86400 )) )) +%Y-%m-%dT%H:%M:%SZ --utc)
+
+    printf "EARLIEST_PR\t%s" $EARLIEST_PR >> ${DATADIR}/times.tsv
+    printf "LATEST_DATE\t%s" $LATEST_DATE >> ${DATADIR}/times.tsv
+    printf "MAX_SPAN_DATE\t%s" $MAX_SPAN_DATE >> ${DATADIR}/times.tsv
+    printf "LONG_SPAN_DATE\t%s" $LONG_SPAN_DATE >> ${DATADIR}/times.tsv
+    printf "SHORT_SPAN_DATE\t%s" $SHORT_SPAN_DATE >> ${DATADIR}/times.tsv
+
+    #limit to max span of analysis
+    if [[ "$EARLIEST_PR" < "$MAX_SPAN_DATE" ]]; then
+        EARLIEST_PR=$MAX_SPAN_DATE
+    fi
 
     echo 'https://api.github.com/repos/'${REPO}'/pulls/comments?since='${EARLIEST_PR}'&per_page=100' | GITHUB_TOKEN=$GITHUB_TOKEN ALLCOMMENTS="" ${DIR}/fetch-comments.sh | gzip -c > ${DATADIR}/pull-comments.gz
     echo 'https://api.github.com/repos/'${REPO}'/issues/comments?since='${EARLIEST_PR}'&per_page=100' | GITHUB_TOKEN=$GITHUB_TOKEN ALLCOMMENTS="" ${DIR}/fetch-comments.sh | gzip -c > ${DATADIR}/issue-comments.gz
@@ -219,33 +253,47 @@ if [ -z "${DATADIR}" ] || [ ! -e "${DATADIR}" ] ; then
         printf "github_pull_sample_time\t%f\n" ${github_pull_sample_time} >> ${DATADIR}/times.tsv
     fi
 
+    data_pull_time=$(( $(date +%s) - ${data_pull_start_time} ))
+    printf "data_pull_time\t%d\n" $data_pull_time >> ${DATADIR}/times.tsv
+
 elif [ -d "${DATADIR}" ]; then
     echo "we'll process existing data  ${DATADIR}"
     echo
 
     #catch up on some state we might need
     EARLIEST_PR=$(zcat ${DATADIR}/pulls.gz | jq -r '.[] | .created_at' | sort -r | tail -n1)
+    LATEST_DATE=$(zcat ${DATADIR}/pulls.gz | jq -r '.[] | .updated_at' | sort | tail -n1)
+    MAX_SPAN_DATE=$(date @$(( $(date -d "$LATEST_DATE" +%s) - $(( $MAX_SPAN_DAYS * 86400 )) )) +%Y-%m-%dT%H:%M:%SZ --utc)
+    LONG_SPAN_DATE=$(date @$(( $(date -d "$LATEST_DATE" +%s) - $(( $LONG_SPAN_DAYS * 86400 )) )) +%Y-%m-%dT%H:%M:%SZ --utc)
+    SHORT_SPAN_DATE=$(date @$(( $(date -d "$LATEST_DATE" +%s) - $(( $SHORT_SPAN_DAYS * 86400 )) )) +%Y-%m-%dT%H:%M:%SZ --utc)
+
+    #limit to max span of analysis
+    if [[ "$EARLIEST_PR" < "$MAX_SPAN_DATE" ]]; then
+        EARLIEST_PR=$MAX_SPAN_DATE
+    fi
 else
     echo "${DATADIR} exists but isn't a directory, run without that param and we'll create a directory to hold data"
     exit 1
 fi
 
+#truncate stats time file
+> ${DATADIR}/statstimes.tsv
+
 echo "computing stats..."
 starttime=$(date +%s)
+
+printf "stats_start_time\t%d\n" $starttime >> ${DATADIR}/statstimes.tsv
 
 #truncate stats file
 > ${DATADIR}/stats.json
 
 #metadata and identification
 echo "metadata"
-cat ${DATADIR}/repo | jq -f ${DIR}/metadata.jq >> ${DATADIR}/stats.json
+cat ${DATADIR}/repo | jq -c -f ${DIR}/metadata.jq >> ${DATADIR}/stats.json
 
 echo "bytes of code per language"
 cat ${DATADIR}/languages.json | jq -c '{"stat":"languages", data: .}' >> ${DATADIR}/stats.json
 
-
-#truncate stats time file
-> ${DATADIR}/statstimes.tsv
 
 cat ${DATADIR}/times.tsv |\
     jq -c -R --slurp 'split("\n")[0:-1] | map(split("\t") | {(.[0]): (.[1] | tonumber)}) | add | {"stat": "data_times", "data": . }' \
@@ -566,6 +614,38 @@ echo "live code lifetime distribution"
 pv ${DATADIR}/metadata.gz | zcat | ag 'live' | cut -f 5 | sort -n |\
     gawk -f ${DIR}/cdf.awk <(echo -n "86400_604800_1209600_2592000_5184000_7776000_15552000_31104000" | tr '_' '\n') - |\
     jq -c --slurp --raw-input --arg stat_name code_lifetime_live_cdf -f ${DIR}/cdf2json.jq\
+    >> ${DATADIR}/stats.json
+
+echo "code birthdate summary (during analysis period)"
+pv ${DATADIR}/metadata.gz | zcat |\
+    gawk -F\\t '$7 >='$(date -d ${EARLIEST_PR} +%s)
+    cut -f 4,7 |\
+    gawk -M -f ${DIR}/groupstats.awk |\
+    jq -c --slurp --raw-input --arg stat_name during_pr_code_birthdate_summary -f ${DIR}/gs2json.jq\
+    >> ${DATADIR}/stats.json
+
+echo "code lifetime summary (during analysis period)"
+pv ${DATADIR}/metadata.gz | zcat |\
+    gawk -F\\t '$7 >='$(date -d ${EARLIEST_PR} +%s)
+    cut -f4,5 |\
+    gawk -M -f ${DIR}/groupstats.awk |\
+    jq -c --slurp --raw-input --arg stat_name during_pr_code_lifetime_summary -f ${DIR}/gs2json.jq\
+    >> ${DATADIR}/stats.json
+
+echo "dead code lifetime distribution (during analysis period)"
+pv ${DATADIR}/metadata.gz | zcat |\
+    gawk -F\\t '$7 >='$(date -d ${EARLIEST_PR} +%s) |\
+    ag 'died' | cut -f 5 | sort -n |\
+    gawk -f ${DIR}/cdf.awk <(echo -n "86400_604800_1209600_2592000_5184000_7776000_15552000_31104000" | tr '_' '\n') - |\
+    jq -c --slurp --raw-input --arg stat_name during_pr_code_lifetime_died_cdf -f ${DIR}/cdf2json.jq\
+    >> ${DATADIR}/stats.json
+
+echo "live code lifetime distribution (during analysis period)"
+pv ${DATADIR}/metadata.gz | zcat |\
+    gawk -F\\t '$7 >='$(date -d ${EARLIEST_PR} +%s) |\
+    ag 'live' | cut -f 5 | sort -n |\
+    gawk -f ${DIR}/cdf.awk <(echo -n "86400_604800_1209600_2592000_5184000_7776000_15552000_31104000" | tr '_' '\n') - |\
+    jq -c --slurp --raw-input --arg stat_name during_pr_code_lifetime_live_cdf -f ${DIR}/cdf2json.jq\
     >> ${DATADIR}/stats.json
 
 #TODO: code lifetime stats per file

--- a/statstool
+++ b/statstool
@@ -617,14 +617,14 @@ pv ${DATADIR}/metadata.gz | zcat | ag 'live' | cut -f 5 | sort -n |\
 
 #TODO: code lifetime stats per file
 
-echo "code lifetime from merged PR summary"
-cat ${DATADIR}/pr_status | (grep 'merged' || true) |\
-    cut -f 5 | LC_ALL=C sort |\
-    LC_ALL=C join -t$'\t' - <(zcat ${DATADIR}/metadata.gz | gawk -F\\t 'BEGIN {OFS="\t"} {print $2, $4, $5}' | LC_ALL=C sort) |\
-    gawk -F\\t 'BEGIN {OFS="\t"} {printf("%s\t%s\n", $2, $3)}' |\
-    gawk -M -f ${DIR}/groupstats.awk |\
-    jq -c --slurp --raw-input --arg stat_name code_lifetime_merged_pr_summary -f ${DIR}/gs2json.jq\
-    >> ${DATADIR}/stats.json
+#echo "code lifetime from merged PR summary"
+#cat ${DATADIR}/pr_status | (grep 'merged' || true) |\
+#    cut -f 5 | LC_ALL=C sort |\
+#    LC_ALL=C join -t$'\t' - <(zcat ${DATADIR}/metadata.gz | gawk -F\\t 'BEGIN {OFS="\t"} {print $2, $4, $5}' | LC_ALL=C sort) |\
+#    gawk -F\\t 'BEGIN {OFS="\t"} {printf("%s\t%s\n", $2, $3)}' |\
+#    gawk -M -f ${DIR}/groupstats.awk |\
+#    jq -c --slurp --raw-input --arg stat_name code_lifetime_merged_pr_summary -f ${DIR}/gs2json.jq\
+#    >> ${DATADIR}/stats.json
 
 #TODO: need to add in code that is merged but not reviewed (as zeros? as different case?)
 #TODO: need to sample these cases
@@ -766,63 +766,63 @@ cat\
     jq -c --slurp --raw-input --arg stat_name commit_review_file_overlap -f ${DIR}/gs2json.jq\
     >> ${DATADIR}/stats.json
 
-echo "lifetime for code from reviewed vs unreviewed commits"
-cat\
-    <(cat ${DATADIR}/reviewed_commits | cut -f 1 |\
-        gawk -F\\t '{printf("%s\treviewed\n", $1)}')\
-    <(cat ${DATADIR}/unreviewed_commits |\
-        gawk -F\\t '{printf("%s\tunreviewed\n", $1)}') |\
-    LC_ALL=C sort |\
-    LC_ALL=C join -t$'\t' - <(zcat ${DATADIR}/metadata.gz | cut -f 2,5 | LC_ALL=C sort) | cut -f 2,3 |\
-    gawk -M -f ${DIR}/groupstats.awk |\
-    jq -c --slurp --raw-input --arg stat_name commit_review_vs_lifetime -f ${DIR}/gs2json.jq\
-    >> ${DATADIR}/stats.json
+#echo "lifetime for code from reviewed vs unreviewed commits"
+#cat\
+#    <(cat ${DATADIR}/reviewed_commits | cut -f 1 |\
+#        gawk -F\\t '{printf("%s\treviewed\n", $1)}')\
+#    <(cat ${DATADIR}/unreviewed_commits |\
+#        gawk -F\\t '{printf("%s\tunreviewed\n", $1)}') |\
+#    LC_ALL=C sort |\
+#    LC_ALL=C join -t$'\t' - <(zcat ${DATADIR}/metadata.gz | cut -f 2,5 | LC_ALL=C sort) | cut -f 2,3 |\
+#    gawk -M -f ${DIR}/groupstats.awk |\
+#    jq -c --slurp --raw-input --arg stat_name commit_review_vs_lifetime -f ${DIR}/gs2json.jq\
+#    >> ${DATADIR}/stats.json
 
-cat\
-    <(cat ${DATADIR}/reviewed_commits | cut -f 1 |\
-        gawk -F\\t '{printf("%s\treviewed\n", $1)}')\
-    <(cat ${DATADIR}/unreviewed_commits |\
-        gawk -F\\t '{printf("%s\tunreviewed\n", $1)}') |\
-    LC_ALL=C sort |\
-    LC_ALL=C join -t$'\t' - <(zcat ${DATADIR}/metadata.gz | ag 'died' | cut -f 2,5 | LC_ALL=C sort) | cut -f 2,3 |\
-    gawk -M -f ${DIR}/groupstats.awk |\
-    jq -c --slurp --raw-input --arg stat_name commit_review_vs_lifetime_died -f ${DIR}/gs2json.jq\
-    >> ${DATADIR}/stats.json
+#cat\
+#    <(cat ${DATADIR}/reviewed_commits | cut -f 1 |\
+#        gawk -F\\t '{printf("%s\treviewed\n", $1)}')\
+#    <(cat ${DATADIR}/unreviewed_commits |\
+#        gawk -F\\t '{printf("%s\tunreviewed\n", $1)}') |\
+#    LC_ALL=C sort |\
+#    LC_ALL=C join -t$'\t' - <(zcat ${DATADIR}/metadata.gz | ag 'died' | cut -f 2,5 | LC_ALL=C sort) | cut -f 2,3 |\
+#    gawk -M -f ${DIR}/groupstats.awk |\
+#    jq -c --slurp --raw-input --arg stat_name commit_review_vs_lifetime_died -f ${DIR}/gs2json.jq\
+#    >> ${DATADIR}/stats.json
 
-cat\
-    <(cat ${DATADIR}/reviewed_commits | cut -f 1 |\
-        gawk -F\\t '{printf("%s\treviewed\n", $1)}')\
-    <(cat ${DATADIR}/unreviewed_commits |\
-        gawk -F\\t '{printf("%s\tunreviewed\n", $1)}') |\
-    LC_ALL=C sort |\
-    LC_ALL=C join -t$'\t' - <(zcat ${DATADIR}/metadata.gz | ag 'live' | cut -f 2,5 | LC_ALL=C sort) | cut -f 2,3 |\
-    gawk -M -f ${DIR}/groupstats.awk |\
-    jq -c --slurp --raw-input --arg stat_name commit_review_vs_lifetime_live -f ${DIR}/gs2json.jq\
-    >> ${DATADIR}/stats.json
+#cat\
+#    <(cat ${DATADIR}/reviewed_commits | cut -f 1 |\
+#        gawk -F\\t '{printf("%s\treviewed\n", $1)}')\
+#    <(cat ${DATADIR}/unreviewed_commits |\
+#        gawk -F\\t '{printf("%s\tunreviewed\n", $1)}') |\
+#    LC_ALL=C sort |\
+#    LC_ALL=C join -t$'\t' - <(zcat ${DATADIR}/metadata.gz | ag 'live' | cut -f 2,5 | LC_ALL=C sort) | cut -f 2,3 |\
+#    gawk -M -f ${DIR}/groupstats.awk |\
+#    jq -c --slurp --raw-input --arg stat_name commit_review_vs_lifetime_live -f ${DIR}/gs2json.jq\
+#    >> ${DATADIR}/stats.json
 
-echo "lines of code for reviewed vs unreviewed commits"
-cat\
-    <(cat ${DATADIR}/reviewed_commits | cut -f1 | gawk '{printf("%s\treviewed\n", $1)}')\
-    <(cat ${DATADIR}/unreviewed_commits | cut -f1 | gawk '{printf("%s\tunreviewed\n", $1)}') |\
-    LC_ALL=C sort |\
-    LC_ALL=C join <(zcat ${DATADIR}/metadata.gz | cut -f 2 | LC_ALL=C sort) - |\
-    LC_ALL=C sort | uniq -c |\
-    gawk '{printf("%s\t%d\n",$3,$1)}' |\
-    gawk -M -f ${DIR}/groupstats.awk |\
-    jq -c --slurp --raw-input --arg stat_name commit_review_size -f ${DIR}/gs2json.jq\
-    >> ${DATADIR}/stats.json
+#echo "lines of code for reviewed vs unreviewed commits"
+#cat\
+#    <(cat ${DATADIR}/reviewed_commits | cut -f1 | gawk '{printf("%s\treviewed\n", $1)}')\
+#    <(cat ${DATADIR}/unreviewed_commits | cut -f1 | gawk '{printf("%s\tunreviewed\n", $1)}') |\
+#    LC_ALL=C sort |\
+#    LC_ALL=C join <(zcat ${DATADIR}/metadata.gz | cut -f 2 | LC_ALL=C sort) - |\
+#    LC_ALL=C sort | uniq -c |\
+#    gawk '{printf("%s\t%d\n",$3,$1)}' |\
+#    gawk -M -f ${DIR}/groupstats.awk |\
+#    jq -c --slurp --raw-input --arg stat_name commit_review_size -f ${DIR}/gs2json.jq\
+#    >> ${DATADIR}/stats.json
 
-echo "lines of code for reviewed vs unreviewed commits by outcome"
-cat\
-    <(cat ${DATADIR}/reviewed_commits | cut -f1 | gawk '{printf("%s\treviewed\n", $1)}')\
-    <(cat ${DATADIR}/unreviewed_commits | cut -f1 | gawk '{printf("%s\tunreviewed\n", $1)}') |\
-    LC_ALL=C sort |\
-    LC_ALL=C join <(zcat ${DATADIR}/metadata.gz | cut -f 2,4 | LC_ALL=C sort) - |\
-    LC_ALL=C sort | uniq -c |\
-    gawk '{printf("%s-%s\t%d\n",$4,$3,$1)}' |\
-    gawk -M -f ${DIR}/groupstats.awk |\
-    jq -c --slurp --raw-input --arg stat_name commit_review_size_by_outcome -f ${DIR}/gs2json.jq\
-    >> ${DATADIR}/stats.json
+#echo "lines of code for reviewed vs unreviewed commits by outcome"
+#cat\
+#    <(cat ${DATADIR}/reviewed_commits | cut -f1 | gawk '{printf("%s\treviewed\n", $1)}')\
+#    <(cat ${DATADIR}/unreviewed_commits | cut -f1 | gawk '{printf("%s\tunreviewed\n", $1)}') |\
+#    LC_ALL=C sort |\
+#    LC_ALL=C join <(zcat ${DATADIR}/metadata.gz | cut -f 2,4 | LC_ALL=C sort) - |\
+#    LC_ALL=C sort | uniq -c |\
+#    gawk '{printf("%s-%s\t%d\n",$4,$3,$1)}' |\
+#    gawk -M -f ${DIR}/groupstats.awk |\
+#    jq -c --slurp --raw-input --arg stat_name commit_review_size_by_outcome -f ${DIR}/gs2json.jq\
+#    >> ${DATADIR}/stats.json
 
 #TODO: commit structuredness within a PR stats
 #length of PR commit messages by outcome


### PR DESCRIPTION
Controlling for differences in timespans of different repos.
We do this by computing several analysis windows consisting of the most recent code (6 mo, 12 mo, 24 mo, 4 years). This should make benchmark results more comparable across repos of different maturity or that have limited data available for various reasons (e.g. can't pull all their pulls or comments because there are too many).